### PR TITLE
Style refactor + input event handler change

### DIFF
--- a/src/d2l-note-edit.js
+++ b/src/d2l-note-edit.js
@@ -273,11 +273,10 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 
 				textarea.d2l-input.d2l-note-edit-error:hover,
 				textarea.d2l-input.d2l-note-edit-error:focus {
-					border-color: var(--d2l-alert-critical-color, --d2l-color-cinnabar);
+					border-color: var(--d2l-color-feedback-error, --d2l-color-cinnabar);
 					border-width: 2px;
 					outline-style: none;
 					outline-width: 0;
-					padding: var(--d2l-input-padding-focus);
 				}
 
 				textarea.d2l-input::placeholder {

--- a/src/d2l-note-edit.js
+++ b/src/d2l-note-edit.js
@@ -302,7 +302,7 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 					class="d2l-input ${this.errormessage ? 'd2l-note-edit-error' : ''}"
 					.value=${this.value}
 					placeholder="${this.placeholder}"
-					@change=${this._handleChange}
+					@input=${this._handleInput}
 					?disabled="${this._makingCall}"
 				></textarea>
 				<d2l-alert role="alert" type="error" .hidden=${!this.errormessage}>${this.errormessage}</d2l-alert>
@@ -331,7 +331,7 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 		`;
 	}
 
-	_handleChange(e) {
+	_handleInput(e) {
 		this.value = e.target && (e.target).value;
 	}
 


### PR DESCRIPTION
- Fix some hover/focus styling issues when errors are shown, caused by a dependence on removed CSS custom variables
- Listen to `input` rather than `change` events on `d2l-note-edit` - there isn't any observable behavioural change for users, but https://github.com/testing-library/user-event no longer supports simulating `change` events on inputs under the expected circumstances and likely won't in the near future, so this will allow it to be testable by dependent apps.

Before:
![d2l-note-error-broken](https://user-images.githubusercontent.com/17710124/84943987-c5f02500-b0aa-11ea-8bd9-840539aca178.JPG)

After:
![d2l-note-error-fixed](https://user-images.githubusercontent.com/17710124/84944017-cc7e9c80-b0aa-11ea-99ac-c301edae989e.JPG)
