### PR TITLE
Increase line height of 'enter note' string

### DIFF
--- a/src/d2l-notes.js
+++ b/src/d2l-notes.js
@@ -262,7 +262,7 @@ export class D2LNotes extends LocalizeMixin(LitElement) {
 
 				.d2l-notes-enter-note-string,
 				.d2l-note-emptystring {
-					line-height: 1;
+					line-height: 1.4;
 					margin-bottom: 0.6rem;
 				}
 			</style>


### PR DESCRIPTION
## Description
If the 'enter note' string wraps onto 2 lines, the lines of text are too close to each other

## Screenshots
### Before - line height of 1
![line-height of 1](https://user-images.githubusercontent.com/13937038/119706628-d9118600-be1f-11eb-9654-642e37e06ed4.png)

### After - line height of 1.4
![image](https://user-images.githubusercontent.com/13937038/119706852-18d86d80-be20-11eb-832a-165ad643942c.png)

