### PR TITLE
Bump user-elements to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@brightspace-ui/core": "^1",
     "@brightspace-ui/intl": "^3.0.1",
-    "@d2l/user-elements": "^3",
+    "@d2l/user-elements": "^4",
     "@polymer/iron-a11y-announcer": "^3.0.2",
     "@polymer/polymer": "^3.0.0",
     "d2l-alert": "github:BrightspaceUI/alert#semver:^4",


### PR DESCRIPTION
## Description
Bump `d2l-user-elements` to `v4.0.0` which adds support for REM font sizing.

This version bump has been tested and causes no noticeable change in behaviour.