### PR TITLE
Make textarea height relative to font size

### DIFF
--- a/src/d2l-note-edit.js
+++ b/src/d2l-note-edit.js
@@ -161,7 +161,7 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 
 					/* need to set px for transitioning in Edge/IE11 */
 					/* height: calc(var(--d2l-note-edit-textarea-line-height) + var(--d2l-note-edit-textarea-padding-vertical) * 2 + 2px); */
-					--d2l-note-edit-textarea-collapsed-height: 37px;
+					--d2l-note-edit-textarea-collapsed-height: 2.3rem;
 					/* height: calc(var(--d2l-note-edit-textarea-line-height) * 4 + var(--d2l-note-edit-textarea-padding-vertical) * 2 + 2px); */
 					--d2l-note-edit-textarea-expanded-height: 95px;
 


### PR DESCRIPTION
## Issue
When increasing the root font size to 20px, the default height of the `textarea` field was overflowing with a scroll bar.

## Solution
Make height of `d2l-note-edit` relative to the root font size using REM.

A different approach I considered was adding an `overflow: hidden` to the collapsed textarea. I decided against this change since it would change existing behavior of the component and not allow the collapsed component to be scrolled.

## Screenshots
### Before:
![scroll](https://user-images.githubusercontent.com/13937038/121066467-8cb73600-c78f-11eb-973d-993001cf4611.jpg)

### After
![no scroll](https://user-images.githubusercontent.com/13937038/121066475-8e80f980-c78f-11eb-9632-240e59d1b699.jpg)
