### PR TITLE
Us132098-d2l_note_discard_behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@d2l/note",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/d2l-note-edit.js
+++ b/src/d2l-note-edit.js
@@ -401,8 +401,7 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 				}
 			}));
 			this.value = '';
-			this._handleFocusout();
-
+			this._removeFocus();
 		}
 	}
 
@@ -411,7 +410,7 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 		window.ShadyCSS && window.ShadyCSS.styleSubtree(this);
 	}
 
-	_handleFocusout() {
+	_removeFocus() {
 		this.removeAttribute('focused');
 		window.ShadyCSS && window.ShadyCSS.styleSubtree(this);
 	}

--- a/src/d2l-note-edit.js
+++ b/src/d2l-note-edit.js
@@ -402,6 +402,7 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 			}));
 			this.value = '';
 			this._handleFocusout();
+
 		}
 	}
 

--- a/src/d2l-note-edit.js
+++ b/src/d2l-note-edit.js
@@ -295,7 +295,6 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 			<div
 				class="d2l-note-edit-main"
 				@focusin=${this._handleFocusin}
-				@focusout=${this._handleFocusout}
 			>
 				<textarea
 					class="d2l-input ${this.errormessage ? 'd2l-note-edit-error' : ''}"
@@ -402,6 +401,7 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 				}
 			}));
 			this.value = '';
+			this._handleFocusout();
 		}
 	}
 


### PR DESCRIPTION
**Description**
Updated cancel button behavior so that it discards input and unfocuses the textblock.  
Clicking outside of the noteblock no longer causes it to shrink and discard text. 

**Rally**
https://rally1.rallydev.com/#/?detail=/userstory/609975380729&fdp=true