### PR TITLE
Lit 2 Conversion

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -30,11 +30,11 @@
 					<d2l-note
 						user='{"name":"Username","pic":{"url":"avatar.png"},"href":"123"}'
 						token="foozleberries"
-						showavatar
-						createdat="2019-04-23T17:08:33.839Z"
+						show-avatar
+						created-at="2019-04-23T17:08:33.839Z"
 						text="This is some text"
-						canedit
-						candelete
+						can-edit
+						can-delete
 						private
 					>
 						<span class="d2l-body-standard" slot="description">Description</span>
@@ -49,12 +49,12 @@
 					<d2l-note
 						user='{"name":"Username","pic":{"url":"avatar.png"},"href":"123"}'
 						token="foozleberries"
-						showavatar
-						createdat="2019-04-23T17:08:33.839Z"
-						dateformat="short"
+						show-avatar
+						created-at="2019-04-23T17:08:33.839Z"
+						date-format="short"
 						text="This is some text"
-						canedit
-						candelete
+						can-edit
+						can-delete
 						private
 					>
 						<span class="d2l-body-standard" slot="description">Description</span>
@@ -69,11 +69,11 @@
 					<d2l-note
 						user='{"name":"Username","pic":{"url":"avatar.png"},"href":"123"}'
 						token="foozleberries"
-						showavatar
-						createdat="2019-04-23T17:08:33.839Z"
+						show-avatar
+						created-at="2019-04-23T17:08:33.839Z"
 						text="This is some text. Long long long. Thisslightlylongtextshouldnothavebeenbrokenmidword. Hereissomelongunbrokentexttotestthatthebrowserwillinsertawordbreakmidwordasitcannotfitononeline. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long. This is some text. Long long long"
-						canedit
-						candelete
+						can-edit
+						can-delete
 						private
 					>
 						<span class="d2l-body-standard" slot="description">Description</span>
@@ -88,11 +88,11 @@
 					<d2l-note
 						user='{"name":"Username","pic":{"url":"avatar.png"},"href":"123"}'
 						token="foozleberries"
-						showavatar
-						createdat="2019-04-23T17:08:33.839Z"
+						show-avatar
+						created-at="2019-04-23T17:08:33.839Z"
 						text="This is some text"
-						canedit
-						candelete
+						can-edit
+						can-delete
 					></d2l-note>
 				</template>
 			</d2l-demo-snippet>
@@ -103,11 +103,11 @@
 					<d2l-note
 						user='{"name":"Username","pic":{"url":"avatar.png"},"href":"123"}'
 						token="foozleberries"
-						showavatar
-						createdat="2019-04-23T17:08:33.839Z"
+						show-avatar
+						created-at="2019-04-23T17:08:33.839Z"
 						text="This is some text"
-						canedit
-						candelete
+						can-edit
+						can-delete
 						me
 					></d2l-note>
 				</template>
@@ -119,8 +119,8 @@
 					<d2l-note
 						user='{"name":"Username","pic":{"url":"avatar.png"},"href":"123"}'
 						token="foozleberries"
-						showavatar
-						createdat="2019-04-23T17:08:33.839Z"
+						show-avatar
+						created-at="2019-04-23T17:08:33.839Z"
 						text="This is some text"
 					></d2l-note>
 				</template>
@@ -132,8 +132,8 @@
 					<d2l-note
 						user='{"name":"Username","pic":{"url":"avatar.png"},"href":"1234"}'
 						token="foozleberries"
-						showavatar
-						createdat="2019-04-23T17:08:33.839Z"
+						show-avatar
+						created-at="2019-04-23T17:08:33.839Z"
 						text="This is some text"
 					></d2l-note>
 				</template>
@@ -144,8 +144,8 @@
 				<template>
 					<d2l-note
 						user='{"name":"Username","pic":{"url":"avatar.png"}}'
-						showavatar
-						createdat="2019-04-23T17:08:33.839Z"
+						show-avatar
+						created-at="2019-04-23T17:08:33.839Z"
 						text="This is some text"
 					></d2l-note>
 				</template>
@@ -164,7 +164,7 @@
 					<d2l-notes
 						id="notes"
 						class="d2l-notes-5"
-						cancreate
+						can-create
 					></d2l-notes>
 				</template>
 			</d2l-demo-snippet>
@@ -174,7 +174,7 @@
 				<template>
 					<d2l-notes
 						class="d2l-notes-3"
-						cancreate
+						can-create
 					></d2l-notes>
 				</template>
 			</d2l-demo-snippet>
@@ -183,7 +183,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-notes
-						cancreate
+						can-create
 					></d2l-notes>
 				</template>
 			</d2l-demo-snippet>
@@ -192,7 +192,7 @@
 			<d2l-demo-snippet>
 				<template>
 					<d2l-notes
-						hasmore
+						has-more
 					></d2l-notes>
 				</template>
 			</d2l-demo-snippet>
@@ -202,9 +202,9 @@
 				<template>
 					<d2l-notes
 						class="d2l-notes-5"
-						cancreate
-						loadmorestring="Load More Comments"
-						loadlessstring="Load Less Comments"
+						can-create
+						load-more-string="Load More Comments"
+						load-less-string="Load Less Comments"
 					></d2l-notes>
 				</template>
 			</d2l-demo-snippet>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,25 @@
 {
   "name": "@d2l/note",
-  "version": "3.4.0",
+  "version": "3.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.16.0"
+        "@babel/highlight": "^7.16.7"
       }
     },
     "@babel/generator": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-      "integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+      "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0",
+        "@babel/types": "^7.17.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -32,109 +32,119 @@
         }
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+    "@babel/helper-environment-visitor": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.2.tgz",
-      "integrity": "sha512-RUVpT0G2h6rOZwqLDTrKk7ksNv7YpAilTnYe1/Q+eDjxEceRMKVWbCsX7t8h6C1qCFi/1Y8WZjcEPBAFG27GPw==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.0.tgz",
-      "integrity": "sha512-qQ84jIs1aRQxaGaxSysII9TuDaguZ5yVrEuC0BN2vcPlalwfLovVmCjbFDPECPXcYM/wLvNFfp8uDOliLxIoUQ==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.0",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.3",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.3",
+        "@babel/types": "^7.17.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       }
     },
     "@brightspace-ui/core": {
-      "version": "1.202.0",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.202.0.tgz",
-      "integrity": "sha512-XySvSaXo8Hb7OTCGeT5XrvHsK/8cK0rEKKfek+QURE1PIGephFqoOrrkIv2NOJi79bySccNrGcqO7Tx0kYTjlg==",
+      "version": "1.236.3",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/core/-/core-1.236.3.tgz",
+      "integrity": "sha512-DygycjONuXUx5FrP5tvoctchJmCEW9i9pj/RLLOG5YGS/LowJu31jYvK5aOg8+nuB2Hox4GTIhhMbmeHtgPF7g==",
       "requires": {
         "@brightspace-ui/intl": "^3",
         "@formatjs/intl-pluralrules": "^1",
@@ -143,7 +153,7 @@
         "ifrau": "^0.39",
         "intl-messageformat": "^7",
         "lit-element": "^2",
-        "lit-html": "^1.4.1",
+        "lit-html": "^1",
         "prismjs": "^1",
         "resize-observer-polyfill": "^1"
       },
@@ -160,14 +170,14 @@
       }
     },
     "@brightspace-ui/intl": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.5.3.tgz",
-      "integrity": "sha512-OBwbcZLjL901VqL0OFwAg8MJqds52PIMecVtBZchaRmCxTV6hvG5mCTxoK/GKiyW3ePWHEF71nVr3MT/dbU2jQ=="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@brightspace-ui/intl/-/intl-3.9.0.tgz",
+      "integrity": "sha512-GpAwEwWBgjYrTWr9TLCGMUQAinQvtgjBjSsaxTSuzPr+KbNyZxNlF67tDeqRC4Kog9gz3wDh1djsr/6bO5M4AQ=="
     },
     "@d2l/user-elements": {
-      "version": "4.0.1",
-      "resolved": "https://d2lartifacts.jfrog.io/artifactory/api/npm/npm-local/@d2l/user-elements/-/@d2l/user-elements-4.0.1.tgz",
-      "integrity": "sha1-bP/RCAdvmKbCPMSW4zGOaHW6e5g=",
+      "version": "4.0.2",
+      "resolved": "https://d2lartifacts.jfrog.io/artifactory/api/npm/npm-local/@d2l/user-elements/-/@d2l/user-elements-4.0.2.tgz",
+      "integrity": "sha1-/u11fMgJ/w8NGcEwOc2ZAOpBT7I=",
       "requires": {
         "@brightspace-ui/core": "^1.156",
         "d2l-image": "github:Brightspace/d2l-image#semver:^3",
@@ -205,10 +215,9 @@
       "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ=="
     },
     "@lit/reactive-element": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.1.tgz",
-      "integrity": "sha512-nSD5AA2AZkKuXuvGs8IK7K5ZczLAogfDd26zT9l6S7WzvqALdVWcW5vMUiTnZyj5SPcNwNNANj0koeV1ieqTFQ==",
-      "dev": true
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.0.tgz",
+      "integrity": "sha512-0TKSIuJHXNLM0k98fi0AdMIdUoHIYlDHTP+0Vruc2SOs4T6vU1FinXgSvYd8mSrkt+8R+qdRAXvjpqrMXMyBgw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -281,15 +290,15 @@
       }
     },
     "@open-wc/testing": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-3.0.3.tgz",
-      "integrity": "sha512-xJYckO8X9yfWc+ltPlDZjHGTh4ldNmnYsnxNriuUUEEhV5ASdsc+5WEsIS2+9m4lQELj89rNQ7YvhYhawDorhg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-3.1.2.tgz",
+      "integrity": "sha512-2KjEszLItrIEZwCLFjWOSy4rnLzLOpgckrKfZjNA39PpFR3xD9bqYU30TTnLRHBk2B/0ZUbHglyca3iwcF964w==",
       "dev": true,
       "requires": {
         "@esm-bundle/chai": "^4.3.4",
         "@open-wc/chai-dom-equals": "^0.12.36",
         "@open-wc/semantic-dom-diff": "^0.19.5",
-        "@open-wc/testing-helpers": "^2.0.2",
+        "@open-wc/testing-helpers": "^2.1.2",
         "@types/chai": "^4.2.11",
         "@types/chai-dom": "^0.0.9",
         "@types/sinon-chai": "^3.2.3",
@@ -297,13 +306,25 @@
       }
     },
     "@open-wc/testing-helpers": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-2.0.2.tgz",
-      "integrity": "sha512-wJlvDmWo+fIbgykRP21YSP9I9Pf/fo2+dZGaWG77Hw0sIuyB+7sNUDJDkL6kMkyyRecPV6dVRmbLt6HuOwvZ1w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-2.1.2.tgz",
+      "integrity": "sha512-NEdsV47DnOWaw3Wpp85p4qZ6bdubtGPdlTiblk8vSf2HJ2sR4b3ckyRWzsj/k+pcxrDGt8z0Awz71p+048Rrfg==",
       "dev": true,
       "requires": {
         "@open-wc/scoped-elements": "^2.0.1",
-        "lit": "^2.0.0"
+        "lit": "^2.0.0",
+        "lit-html": "^2.0.0"
+      },
+      "dependencies": {
+        "lit-html": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.0.tgz",
+          "integrity": "sha512-dJnevgV8VkCuOXLWrjQopDE8nSy8CzipZ/ATfYQv7z7Dct4abblcKecf50gkIScuwCTzKvRLgvTgV0zzagW4gA==",
+          "dev": true,
+          "requires": {
+            "@types/trusted-types": "^2.0.2"
+          }
+        }
       }
     },
     "@polymer/iron-ajax": {
@@ -347,24 +368,6 @@
         "picomatch": "^2.2.2"
       }
     },
-    "@sinonjs/commons": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
-      "dev": true,
-      "requires": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
     "@types/accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
@@ -381,9 +384,9 @@
       "dev": true
     },
     "@types/body-parser": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
-      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
       "dev": true,
       "requires": {
         "@types/connect": "*",
@@ -391,9 +394,9 @@
       }
     },
     "@types/chai": {
-      "version": "4.2.22",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
-      "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
       "dev": true
     },
     "@types/chai-dom": {
@@ -485,9 +488,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.25",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.25.tgz",
-      "integrity": "sha512-OUJIVfRMFijZukGGwTpKNFprqCCXk5WjNGvUgB/CxxBR40QWSjsNK86+yvGKlCOGc7sbwfHLaXhkG+NsytwBaQ==",
+      "version": "4.17.28",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz",
+      "integrity": "sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -502,15 +505,15 @@
       "dev": true
     },
     "@types/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-e+2rjEwK6KDaNOm5Aa9wNGgyS9oSZU/4pfSMMPYNOfjvFI0WVXm29+ITRFr6aKDvvKo7uU1jV68MW4ScsfDi7Q==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
+      "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
       "dev": true
     },
     "@types/istanbul-lib-coverage": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
       "dev": true
     },
     "@types/istanbul-lib-report": {
@@ -581,15 +584,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-      "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==",
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
     },
     "@types/parse5": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.2.tgz",
-      "integrity": "sha512-+hQX+WyJAOne7Fh3zF5CxPemILIbuhNcqHHodzK9caYOLnC8pD5efmPleRnw0z++LfKUC/sVNMwk0Gap+B0baA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
+      "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
       "dev": true
     },
     "@types/qs": {
@@ -624,29 +627,34 @@
       }
     },
     "@types/sinon": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.6.tgz",
-      "integrity": "sha512-6EF+wzMWvBNeGrfP3Nx60hhx+FfwSg1JJBLAAP/IdIUq0EYkqCYf70VT3PhuhPX9eLD+Dp+lNdpb/ZeHG8Yezg==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.11.tgz",
+      "integrity": "sha512-dmZsHlBsKUtBpHriNjlK0ndlvEh8dcb9uV9Afsbt89QIyydpC7NcR+nWlAhASfy3GHnxTl4FX/aKE7XZUt/B4g==",
       "dev": true,
       "requires": {
-        "@sinonjs/fake-timers": "^7.1.0"
+        "@types/sinonjs__fake-timers": "*"
       }
     },
     "@types/sinon-chai": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.5.tgz",
-      "integrity": "sha512-bKQqIpew7mmIGNRlxW6Zli/QVyc3zikpGzCa797B/tRnD9OtHvZ/ts8sYXV+Ilj9u3QRaUEM8xrjgd1gwm1BpQ==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.8.tgz",
+      "integrity": "sha512-d4ImIQbT/rKMG8+AXpmcan5T2/PNeSjrYhvkwet6z0p8kzYtfgA32xzOBlbU0yqJfq+/0Ml805iFoODO0LP5/g==",
       "dev": true,
       "requires": {
         "@types/chai": "*",
         "@types/sinon": "*"
       }
     },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
+      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
+      "dev": true
+    },
     "@types/trusted-types": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
-      "dev": true
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
     "@types/ws": {
       "version": "7.4.7",
@@ -751,9 +759,9 @@
       }
     },
     "@web/dev-server": {
-      "version": "0.1.28",
-      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.28.tgz",
-      "integrity": "sha512-964NqgatvFWX7LM8QGlB1XpcJoUQRXZPiEn3XKgDIUSNS6JNCjGfQQ+TfxBlT5KBHYJakDYbTk+sdEeRi2gaLw==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@web/dev-server/-/dev-server-0.1.30.tgz",
+      "integrity": "sha512-nUKR+lq06gaCvH6vKmfhPe/Kka1Xp7yN1FN5NEx+Yk4+9CyxZ3UJt2eHXedrcz+XCafxExW114ElEDgCahJowg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.11",
@@ -799,16 +807,16 @@
       }
     },
     "@web/dev-server-rollup": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.13.tgz",
-      "integrity": "sha512-QaxEtsdL6+fktIa1ZL8VEtq4U7WB7ikKEnxkbhUpFknB+WSvwx6DUrvyBDuPckunpczCnljXBFPugu+2W6N8Fg==",
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.3.15.tgz",
+      "integrity": "sha512-hhxvBmNIY19vXeocYB1IBOuhpVpy1L7jbwBarmvC0QJKZsgkxssNTzXJ8iga70c2+H0c/rBz1xUaKuAcov0uOA==",
       "dev": true,
       "requires": {
         "@rollup/plugin-node-resolve": "^11.0.1",
         "@web/dev-server-core": "^0.3.16",
         "nanocolors": "^0.2.1",
         "parse5": "^6.0.1",
-        "rollup": "^2.58.0",
+        "rollup": "^2.66.1",
         "whatwg-url": "^11.0.0"
       }
     },
@@ -823,16 +831,16 @@
       }
     },
     "@web/test-runner": {
-      "version": "0.13.21",
-      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.13.21.tgz",
-      "integrity": "sha512-Aj/Z6vvKgWQlLneg/kGoyw9CWWpiziRzJkqG8ZrblYsWdH/eMJ8+B1KVsjqb+sXjiMg3YTkU9E4IGa7c3nHMvg==",
+      "version": "0.13.27",
+      "resolved": "https://registry.npmjs.org/@web/test-runner/-/test-runner-0.13.27.tgz",
+      "integrity": "sha512-yVhXK9sPJE2VQs1/KPTIeQvUxh+02OZkn+tgcr0+W8ovvrFD4ucF2X26cpeOTuD+Y67ERUi/EopIze3aelw6sg==",
       "dev": true,
       "requires": {
         "@web/browser-logs": "^0.2.2",
         "@web/config-loader": "^0.1.3",
         "@web/dev-server": "^0.1.24",
-        "@web/test-runner-chrome": "^0.10.4",
-        "@web/test-runner-commands": "^0.5.10",
+        "@web/test-runner-chrome": "^0.10.7",
+        "@web/test-runner-commands": "^0.6.0",
         "@web/test-runner-core": "^0.10.22",
         "@web/test-runner-mocha": "^0.7.5",
         "camelcase": "^6.2.0",
@@ -844,18 +852,30 @@
         "nanocolors": "^0.2.1",
         "portfinder": "^1.0.28",
         "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "@web/test-runner-commands": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/@web/test-runner-commands/-/test-runner-commands-0.6.1.tgz",
+          "integrity": "sha512-P4aQqp0duumeGdGxQ8TwLnplkrXzpLqb47eSEEqBRS//C1H7s6VskaqEng+k0dbk+cSpEa4RuZGY/G5k8aTjTw==",
+          "dev": true,
+          "requires": {
+            "@web/test-runner-core": "^0.10.20",
+            "mkdirp": "^1.0.4"
+          }
+        }
       }
     },
     "@web/test-runner-chrome": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.10.4.tgz",
-      "integrity": "sha512-MqdmhOh/v7KakDYUnXIpypC5/mxAP/0jw475n8k6eqdMxJ4KIVirwIv582iEV4LU64RQAl8NXxSZkzAapzKC7Q==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-chrome/-/test-runner-chrome-0.10.7.tgz",
+      "integrity": "sha512-DKJVHhHh3e/b6/erfKOy0a4kGfZ47qMoQRgROxi9T4F9lavEY3E5/MQ7hapHFM2lBF4vDrm+EWjtBdOL8o42tw==",
       "dev": true,
       "requires": {
         "@web/test-runner-core": "^0.10.20",
         "@web/test-runner-coverage-v8": "^0.4.8",
-        "chrome-launcher": "^0.14.0",
-        "puppeteer-core": "^11.0.0"
+        "chrome-launcher": "^0.15.0",
+        "puppeteer-core": "^13.1.3"
       }
     },
     "@web/test-runner-commands": {
@@ -869,9 +889,9 @@
       }
     },
     "@web/test-runner-core": {
-      "version": "0.10.22",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.10.22.tgz",
-      "integrity": "sha512-0jzJIl/PTZa6PCG/noHAFZT2DTcp+OYGmYOnZ2wcHAO3KwtJKnBVSuxgdOzFdmfvoO7TYAXo5AH+MvTZXMWsZw==",
+      "version": "0.10.25",
+      "resolved": "https://registry.npmjs.org/@web/test-runner-core/-/test-runner-core-0.10.25.tgz",
+      "integrity": "sha512-gH8VXyZbwf+sqPiH4cnXYf86SqwBLtou+0LFFCLaDQRbMlrfi5byAISt39fNX2ejd46bF1cZn6DK+mzb/Xjccw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.11",
@@ -953,13 +973,13 @@
       "dev": true
     },
     "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
       "requires": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       }
     },
     "acorn": {
@@ -1264,15 +1284,15 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.1024.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1024.0.tgz",
-      "integrity": "sha512-FgGvRtxTzgU7iBXG/+hCGqdE2U2gF/NqVDQsTBjrLIbOMiNNheL8uzxcmIKKZ49lFlWwVkM0HNmpEmA5hiLinw==",
+      "version": "2.1088.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1088.0.tgz",
+      "integrity": "sha512-KtGJTvMPJL6QynasbSMNvz7Onc5ejebY6NzuUvgrw6sNohNJDR/3J/0e016ocQwvEq79MNK4v4EsxNi9eMELtg==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
@@ -1306,9 +1326,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
-      "integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
+      "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
       "dev": true
     },
     "babel-eslint": {
@@ -1489,9 +1509,9 @@
       "dev": true
     },
     "bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true
     },
     "cache-base": {
@@ -1548,9 +1568,9 @@
       }
     },
     "camelcase": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
     },
     "caseless": {
@@ -1560,9 +1580,9 @@
       "dev": true
     },
     "chai-a11y-axe": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/chai-a11y-axe/-/chai-a11y-axe-1.3.2.tgz",
-      "integrity": "sha512-/jYczmhGUoCfEcsrkJwjecy3PJ31T9FxFdu2BDlAwR/sX1nN3L2XmuPP3tw8iYk6LPqdF7K11wwFr3yUZMv5MA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chai-a11y-axe/-/chai-a11y-axe-1.4.0.tgz",
+      "integrity": "sha512-m7J6DVAl1ePL2ifPKHmwQyHXdCZ+Qfv+qduh6ScqcDfBnJEzpV1K49TblujM45j1XciZOFeFNqMb2sShXMg/mw==",
       "dev": true,
       "requires": {
         "axe-core": "^4.3.3"
@@ -1612,9 +1632,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -1634,9 +1654,9 @@
       "dev": true
     },
     "chrome-launcher": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.14.2.tgz",
-      "integrity": "sha512-Nk8DUCIfPR6p9WClPPFeP2ztpAdkT8xueoiDS03csea1uoJjm4w0p5Oy1hjykyjT1EQ0MMrEshLD3C8gHXyiZw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.0.tgz",
+      "integrity": "sha512-ZQqX5kb9H0+jy1OqLnWampfocrtSZaGl7Ny3F9GRha85o4odbL8x55paUzh51UC7cEmZ5obp3H2Mm70uC2PpRA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -1783,6 +1803,12 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1870,9 +1896,9 @@
       }
     },
     "command-line-args": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
-      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "dev": true,
       "requires": {
         "array-back": "^3.1.0",
@@ -1952,6 +1978,12 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -1974,12 +2006,12 @@
       }
     },
     "content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "5.2.1"
       }
     },
     "content-type": {
@@ -1995,6 +2027,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "cookies": {
@@ -2036,6 +2076,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.7"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -2083,29 +2132,14 @@
         "type": "^1.0.1"
       }
     },
-    "d2l-colors": {
-      "version": "github:BrightspaceUI/colors#eca32f3d4caff4e739fe4e87c6a2eb15ea1f19a9",
-      "from": "github:BrightspaceUI/colors#semver:^4",
-      "requires": {
-        "@brightspace-ui/core": "^1",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
     "d2l-fetch": {
       "version": "github:Brightspace/d2l-fetch#dc6db038fae12889e6f3243344b3ada5e7fcf94d",
       "from": "github:Brightspace/d2l-fetch#semver:^2"
     },
     "d2l-hypermedia-constants": {
-      "version": "6.54.0",
-      "resolved": "https://registry.npmjs.org/d2l-hypermedia-constants/-/d2l-hypermedia-constants-6.54.0.tgz",
-      "integrity": "sha512-e9hAdtX/7/i7mkgFWpdNOzTJPAOSZE34We2tFJeSCJ+pxpyz4qIrUqITLQ4DiKxblshoQF/HGCTqJFTE5IUu6w=="
-    },
-    "d2l-icons": {
-      "version": "github:BrightspaceUI/icons#2963a737440eea4b4abbc1dbb0bce6429e543da3",
-      "from": "github:BrightspaceUI/icons#semver:^6",
-      "requires": {
-        "@brightspace-ui/core": "^1"
-      }
+      "version": "6.61.0",
+      "resolved": "https://registry.npmjs.org/d2l-hypermedia-constants/-/d2l-hypermedia-constants-6.61.0.tgz",
+      "integrity": "sha512-lyv4ADqU6mz+F635kE/JrNWg/5UwbBFtKkJD4kTnu2o6Nygq2mE4Eo8QofBr1xVjuhTNEvkn/FMblrX4p9LVGw=="
     },
     "d2l-image": {
       "version": "github:Brightspace/d2l-image#5dad48cf1b3dc3a67bce902a3cebd16ba010cefc",
@@ -2133,14 +2167,13 @@
       }
     },
     "d2l-users": {
-      "version": "github:BrightspaceHypermediaComponents/users#14a55f2d0a451f4b695e149a146c8c2662d2d13e",
+      "version": "github:BrightspaceHypermediaComponents/users#1cee377c8e684aa2fe22666e1e1d03d2707ee1c4",
       "from": "github:BrightspaceHypermediaComponents/users#semver:^2",
       "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "d2l-colors": "github:BrightspaceUI/colors#semver:^4",
+        "@brightspace-ui/core": "^1",
+        "@polymer/polymer": "^3",
         "d2l-fetch": "github:Brightspace/d2l-fetch#semver:^2",
         "d2l-hypermedia-constants": "^6",
-        "d2l-icons": "github:BrightspaceUI/icons#semver:^6",
         "d2l-polymer-siren-behaviors": "github:Brightspace/polymer-siren-behaviors#semver:^1",
         "d2l-typography": "github:BrightspaceUI/typography#semver:^7"
       }
@@ -2152,9 +2185,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -2300,9 +2333,9 @@
       "dev": true
     },
     "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.1.1.tgz",
+      "integrity": "sha512-jxwFW+yrVOLdwqIWvowFOM8UPdhZnvOF6mhXQQLXMxBDLtv2JVJlVJPEwkDv9prqscEtGtmnxuuI6pQKStK1vA==",
       "dev": true
     },
     "detect-file": {
@@ -2312,9 +2345,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.901419",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
-      "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
+      "version": "0.0.969999",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.969999.tgz",
+      "integrity": "sha512-6GfzuDWU0OFAuOvBokXpXPLxjOJ5DZ157Ue3sGQQM3LgAamb8m0R0ruSfN0DDu+XG5XJgT50i6zZ/0o8RglreQ==",
       "dev": true
     },
     "diff": {
@@ -2426,6 +2459,12 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -2508,14 +2547,14 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.56",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.56.tgz",
+      "integrity": "sha512-YUhqzoMnIjMW5y8FzaMxsCu0eWCwq32GrlwhOhbQmL5OiZReWFm/KvRiYuvqf3CaG/zZ36Kyb4KfVe674cafCQ==",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
       }
     },
     "es6-iterator": {
@@ -2863,9 +2902,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
-          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
           "dev": true
         }
       }
@@ -3015,9 +3054,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3299,6 +3338,12 @@
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
@@ -3646,6 +3691,12 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3875,6 +3926,12 @@
             "readable-stream": "^2.0.2"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3927,16 +3984,16 @@
       "dev": true
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
     },
@@ -3950,9 +4007,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
       "dev": true
     },
     "gulp": {
@@ -4154,9 +4211,9 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
     "has-tostringtag": {
@@ -4294,16 +4351,16 @@
       }
     },
     "http-errors": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
         "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
+        "toidentifier": "1.0.1"
       },
       "dependencies": {
         "depd": {
@@ -4351,14 +4408,14 @@
       "dev": true
     },
     "ifrau": {
-      "version": "0.39.3",
-      "resolved": "https://registry.npmjs.org/ifrau/-/ifrau-0.39.3.tgz",
-      "integrity": "sha512-LFPc3UnjJ7UU6v49qMO0SxVIcvRAMKkcYnae/TXZcB8w6VBifwvov6Gsz8OL4wTe1X+3YKFA0U/zEmG0wgzmfA=="
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/ifrau/-/ifrau-0.39.6.tgz",
+      "integrity": "sha512-vpXVjFSbUxnIh2MEhPLy/il0yDurJladnDxLVlT2Ty8bZ30KoDgJRadzJ6SHeBXFLxP98e/IeajMUmlzW5pGpw=="
     },
     "ignore": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-      "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
     },
     "import-fresh": {
@@ -4638,9 +4695,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -4888,9 +4945,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.5.tgz",
-      "integrity": "sha512-5+19PlhnGabNWB7kOFnuxT8H3T/iIyQzIbQMxXsURmmvKg86P2sbkrGOT77VnHw0Qr0gc2XzRaRfMZYYbSQCJQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
+      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -4898,9 +4955,9 @@
       }
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "dev": true
     },
     "jpeg-js": {
@@ -5101,6 +5158,12 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -5184,31 +5247,28 @@
       }
     },
     "lit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.2.tgz",
-      "integrity": "sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.0.tgz",
+      "integrity": "sha512-FDyxUuczo6cJJY/2Bkgfh1872U4ikUvmK1Cb6+lYC1CW+QOo8CaWXCpvPKFzYsz0ojUxoruBLVrECc7VI2f1dQ==",
       "requires": {
-        "@lit/reactive-element": "^1.0.0",
-        "lit-element": "^3.0.0",
-        "lit-html": "^2.0.0"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.2.0"
       },
       "dependencies": {
         "lit-element": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.1.tgz",
-          "integrity": "sha512-vs9uybH9ORyK49CFjoNGN85HM9h5bmisU4TQ63phe/+GYlwvY/3SIFYKdjV6xNvzz8v2MnVC+9+QOkPqh+Q3Ew==",
-          "dev": true,
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
+          "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
           "requires": {
-            "@lit/reactive-element": "^1.0.0",
-            "lit-html": "^2.0.0"
+            "@lit/reactive-element": "^1.3.0",
+            "lit-html": "^2.2.0"
           }
         },
         "lit-html": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.1.tgz",
-          "integrity": "sha512-KF5znvFdXbxTYM/GjpdOOnMsjgRcFGusTnB54ixnCTya5zUR0XqrDRj29ybuLS+jLXv1jji6Y8+g4W7WP8uL4w==",
-          "dev": true,
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.0.tgz",
+          "integrity": "sha512-dJnevgV8VkCuOXLWrjQopDE8nSy8CzipZ/ATfYQv7z7Dct4abblcKecf50gkIScuwCTzKvRLgvTgV0zzagW4gA==",
           "requires": {
             "@types/trusted-types": "^2.0.2"
           }
@@ -5344,9 +5404,9 @@
       }
     },
     "marky": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.2.tgz",
-      "integrity": "sha512-k1dB2HNeaNyORco8ulVEhctyEGkKHb2YWAhDsxeFlW2nROIirsctBYzKwwS3Vza+sKTS1zO4Z+n9/+9WbGLIxQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.4.tgz",
+      "integrity": "sha512-zd2/GiSn6U3/jeFVZ0J9CA1LzQ8RfIVvXkb/U0swFHF/zT+dVohTAWjmo2DcIuofmIIIROlwTbd+shSeXmxr0w==",
       "dev": true
     },
     "matchdep": {
@@ -5516,9 +5576,9 @@
       }
     },
     "mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "dev": true
     },
     "mime-db": {
@@ -5543,9 +5603,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -5615,9 +5675,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.30",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
     "nanomatch": {
@@ -5646,15 +5706,15 @@
       "dev": true
     },
     "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true
     },
     "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "nice-try": {
@@ -5673,9 +5733,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-      "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
@@ -5784,9 +5844,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
       "dev": true
     },
     "object-keys": {
@@ -5858,9 +5918,9 @@
       }
     },
     "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
       "requires": {
         "ee-first": "1.1.1"
@@ -5938,6 +5998,12 @@
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
@@ -6157,9 +6223,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
     "pify": {
@@ -6199,37 +6265,43 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.16.3.tgz",
-      "integrity": "sha512-nfJx/OpIb/8OexL3rYGxNN687hGyaM3XNpfuMzoPlrekURItyuiHHsNhC9oQCx3JDmCn5O3EyyyFCnrZjH6MpA==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.19.2.tgz",
+      "integrity": "sha512-2JmGWr/Iw/Uu27bZULeHgjn8doNrRVxIYdhspMuMlfKNpzwAe/sfm7wH8uey6jiZxnPL4bC5V4ACQcF4dAGWnw==",
       "dev": true,
       "requires": {
-        "playwright-core": "=1.16.3"
+        "playwright-core": "1.19.2"
       },
       "dependencies": {
         "playwright-core": {
-          "version": "1.16.3",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.16.3.tgz",
-          "integrity": "sha512-16hF27IvQheJee+DbhC941AUZLjbJgfZFWi9YPS4LKEk/lKFhZI+9TiFD0sboYqb9eaEWvul47uR5xxTVbE4iw==",
+          "version": "1.19.2",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.19.2.tgz",
+          "integrity": "sha512-OsL3sJZIo1UxKNWSP7zW7sk3FyUGG06YRHxHeBw51eIOxTCQRx5t+hXd0cvXashN2CHnd3hIZTs2aKa/im4hZQ==",
           "dev": true,
           "requires": {
-            "commander": "^8.2.0",
-            "debug": "^4.1.1",
-            "extract-zip": "^2.0.1",
-            "https-proxy-agent": "^5.0.0",
-            "jpeg-js": "^0.4.2",
-            "mime": "^2.4.6",
-            "pngjs": "^5.0.0",
-            "progress": "^2.0.3",
-            "proper-lockfile": "^4.1.1",
-            "proxy-from-env": "^1.1.0",
-            "rimraf": "^3.0.2",
-            "socks-proxy-agent": "^6.1.0",
-            "stack-utils": "^2.0.3",
-            "ws": "^7.4.6",
-            "yauzl": "^2.10.0",
-            "yazl": "^2.5.1"
+            "commander": "8.3.0",
+            "debug": "4.3.3",
+            "extract-zip": "2.0.1",
+            "https-proxy-agent": "5.0.0",
+            "jpeg-js": "0.4.3",
+            "mime": "3.0.0",
+            "pngjs": "6.0.0",
+            "progress": "2.0.3",
+            "proper-lockfile": "4.1.2",
+            "proxy-from-env": "1.1.0",
+            "rimraf": "3.0.2",
+            "socks-proxy-agent": "6.1.1",
+            "stack-utils": "2.0.5",
+            "ws": "8.4.2",
+            "yauzl": "2.10.0",
+            "yazl": "2.5.1"
           }
+        },
+        "ws": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.2.tgz",
+          "integrity": "sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==",
+          "dev": true
         }
       }
     },
@@ -6246,9 +6318,9 @@
       }
     },
     "pngjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
       "dev": true
     },
     "portfinder": {
@@ -6301,9 +6373,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
-      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg=="
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -6386,37 +6458,37 @@
       "dev": true
     },
     "puppeteer-core": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-11.0.0.tgz",
-      "integrity": "sha512-hfQ39KNP0qKplQ86iaCNXHH9zpWlV01UFdggt2qffgWeCBF9KMavwP/k/iK/JidPPWfOnKZhDLSHZVSUr73DtA==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-13.5.0.tgz",
+      "integrity": "sha512-jBHWru2UmB4NV+kbbWc52O3PCS8PGwYTcqPN4RobfZDmuAwaW4JN4R5ntMqlw1OLp4bmm07UuhR9lQXAdtXT1w==",
       "dev": true,
       "requires": {
-        "debug": "4.3.2",
-        "devtools-protocol": "0.0.901419",
+        "cross-fetch": "3.1.5",
+        "debug": "4.3.3",
+        "devtools-protocol": "0.0.969999",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.0",
-        "node-fetch": "2.6.5",
         "pkg-dir": "4.2.0",
         "progress": "2.0.3",
         "proxy-from-env": "1.1.0",
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.2.3"
+        "ws": "8.5.0"
       },
       "dependencies": {
         "ws": {
-          "version": "8.2.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
           "dev": true
         }
       }
     },
     "qs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -6435,40 +6507,34 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
-      "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "dev": true,
       "requires": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.3",
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "depd": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
-        },
         "http-errors": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-          "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+          "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
           "dev": true,
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "2.0.0",
             "inherits": "2.0.4",
-            "setprototypeof": "1.1.1",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.0"
+            "setprototypeof": "1.2.0",
+            "statuses": "2.0.1",
+            "toidentifier": "1.0.1"
           }
         },
-        "setprototypeof": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
           "dev": true
         }
       }
@@ -6752,13 +6818,14 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+        "is-core-module": "^2.8.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "resolve-dir": {
@@ -6872,9 +6939,9 @@
       }
     },
     "rollup": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.59.0.tgz",
-      "integrity": "sha512-l7s90JQhCQ6JyZjKgo7Lq1dKh2RxatOM+Jr6a9F7WbS9WgKbocyUSeLmZl8evAse7y96Ae98L2k1cBOwWD8nHw==",
+      "version": "2.70.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.0.tgz",
+      "integrity": "sha512-iEzYw+syFxQ0X9RefVwhr8BA2TNJsTaX8L8dhyeyMECDbmiba+8UQzcu+xZdji0+JQ+s7kouQnw+9Oz5M19XKA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -6905,9 +6972,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true
     },
     "safe-regex": {
@@ -7018,9 +7085,9 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
-      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "simple-git": {
@@ -7033,9 +7100,9 @@
       }
     },
     "siren-parser": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/siren-parser/-/siren-parser-8.5.0.tgz",
-      "integrity": "sha512-lQkYR4I06dBUGAtiTc32tHCvXT4ViBjinqjjy2yNZt/fpd5MhJMAOIoNe2OgQQcROhRn6sZblW1FrFZlTyEEAg=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/siren-parser/-/siren-parser-8.5.1.tgz",
+      "integrity": "sha512-qhJsXQbXI0aLQqo3KjrnzAgqRvy+jbouRkVLTps0HVvQJ19SrwNzeI85v6oviw98A1BI9ZnfaV2mC1hxDahLpg=="
     },
     "slash": {
       "version": "3.0.0",
@@ -7233,19 +7300,19 @@
       }
     },
     "socks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.1.tgz",
-      "integrity": "sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
       "dev": true,
       "requires": {
         "ip": "^1.1.5",
-        "smart-buffer": "^4.1.0"
+        "smart-buffer": "^4.2.0"
       }
     },
     "socks-proxy-agent": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.0.tgz",
-      "integrity": "sha512-57e7lwCN4Tzt3mXz25VxOErJKXlPfXmkMLnk310v/jwW20jWRVcgsOit+xNkN3eIEdB47GwnfAEBLacZ/wVIKg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
+      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
       "dev": true,
       "requires": {
         "agent-base": "^6.0.2",
@@ -7311,9 +7378,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
-      "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
     "split-string": {
@@ -7416,14 +7483,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        }
       }
     },
     "stringstream": {
@@ -7464,6 +7523,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
     },
     "sver-compat": {
       "version": "1.5.0",
@@ -7642,6 +7707,12 @@
             "util-deprecate": "~1.0.1"
           }
         },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -7764,9 +7835,9 @@
       }
     },
     "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
     },
     "tough-cookie": {
@@ -7830,12 +7901,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "type-fest": {
       "version": "0.21.3",
@@ -8072,9 +8137,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
-      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
+      "integrity": "sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -8166,6 +8231,12 @@
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
           }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
@@ -8329,9 +8400,9 @@
       }
     },
     "ws": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
-      "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
       "dev": true
     },
     "xml2js": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@d2l/user-elements": "^4.0.1",
     "d2l-users": "BrightspaceHypermediaComponents/users#semver:^2",
     "intl-messageformat": "^2.2.0",
-    "lit-element": "^2.1.0"
+    "lit": "^2.2.0"
   },
   "devDependencies": {
     "@open-wc/testing": "^3.0.0-next.5",

--- a/src/d2l-note-edit.js
+++ b/src/d2l-note-edit.js
@@ -48,8 +48,8 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 		 */
 		placeholder: { type: String },
 		/**
-* Text for the 'Add' button. Defaults to langified 'Add'
-*/
+		 * Text for the 'Add' button. Defaults to langified 'Add'
+		 */
 		addNoteString: { type: String, attribute: 'add-note-string' },
 		/**
 		 * Text for the 'Save' button. Defaults to langified 'Save'

--- a/src/d2l-note-edit.js
+++ b/src/d2l-note-edit.js
@@ -6,7 +6,7 @@ import '@brightspace-ui/core/components/icons/icon.js';
  * Import LitElement base class, html helper function,
  * and TypeScript decorators
  **/
-import { html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 
 import { announce } from '@brightspace-ui/core/helpers/announce';
 import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
@@ -34,52 +34,50 @@ import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
  */
 export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Indicates this control creates a new item
-			 */
-			new: { type: Boolean },
-			/**
-			 * Contents of note. Updates with change event on textarea
-			 */
-			value: { type: String },
-			/**
-			 * Placeholder for textarea
-			 */
-			placeholder: { type: String },
-			/**
-			 * Text for the 'Add' button. Defaults to langified 'Add'
-			 */
-			addnotestring: { type: String },
-			/**
-			 * Text for the 'Save' button. Defaults to langified 'Save'
-			 */
-			savenotestring: { type: String },
-			/**
-			 * Label for the 'Discard' button. Defaults to langified 'Discard'
-			 */
-			discardnotestring: { type: String },
-			/**
-			 * True while a request is being made, disables the components, defaults to false
-			 */
-			_makingCall: { type: Boolean },
-			/**
-			 * Indicates whether the component is in its expanded state. If true,
-			 * The textarea is set to its maximum height, the controls are visible.
-			 */
-			expanded: { type: Boolean, reflect: true },
-			/**
-			 * The error message to show if set. Shows a d2l-alert component and
-			 * sets the color of the textarea to --d2l-alert-critical-color
-			 */
-			errormessage: { type: String },
-			/**
-			 * Indicates whether the component is in its focused state. If true,
-			 * The textarea is set to have its text area selected, and expanded.
-			 */
-			focused: { type: Boolean, reflect: true },
-		};
+	static properties = {
+		/**
+		 * Indicates this control creates a new item
+		 */
+		new: { type: Boolean },
+		/**
+		 * Contents of note. Updates with change event on textarea
+		 */
+		value: { type: String },
+		/**
+		 * Placeholder for textarea
+		 */
+		placeholder: { type: String },
+		/**
+* Text for the 'Add' button. Defaults to langified 'Add'
+*/
+		addNoteString: { type: String, attribute: 'add-note-string' },
+		/**
+		 * Text for the 'Save' button. Defaults to langified 'Save'
+		 */
+		saveNoteString: { type: String, attribute: 'save-note-string' },
+		/**
+		 * Label for the 'Discard' button. Defaults to langified 'Discard'
+		 */
+		discardNoteString: { type: String, attribute: 'discard-note-string' },
+		/**
+		 * True while a request is being made, disables the components, defaults to false
+		 */
+		_makingCall: { type: Boolean, state: true },
+		/**
+		 * Indicates whether the component is in its expanded state. If true,
+		 * The textarea is set to its maximum height, the controls are visible.
+		 */
+		expanded: { type: Boolean, reflect: true },
+		/**
+		 * The error message to show if set. Shows a d2l-alert component and
+		 * sets the color of the textarea to --d2l-alert-critical-color
+		 */
+		errorMessage: { type: String, attribute: 'error-message' },
+		/**
+		 * Indicates whether the component is in its focused state. If true,
+		 * The textarea is set to have its text area selected, and expanded.
+		 */
+		focused: { type: Boolean, reflect: true },
 	}
 
 	constructor() {
@@ -127,9 +125,145 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 		}
 	}
 
-	static get styles() {
-		return inputStyles;
-	}
+	static styles = [inputStyles, css`
+		:host {
+			display: block;
+			line-height: 0;
+
+			--d2l-note-edit-spacing: 12px;
+			--d2l-note-edit-textarea-font-size: 1rem;
+
+			/* need to set px for transitioning in Edge/IE11 */
+			/* height: calc(var(--d2l-note-edit-textarea-line-height) + var(--d2l-note-edit-textarea-padding-vertical) * 2 + 2px); */
+			--d2l-note-edit-textarea-collapsed-height: 2.3rem;
+			/* height: calc(var(--d2l-note-edit-textarea-line-height) * 4 + var(--d2l-note-edit-textarea-padding-vertical) * 2 + 2px); */
+			--d2l-note-edit-textarea-expanded-height: 95px;
+
+			--d2l-note-edit-textarea-padding-vertical: 0.5rem;
+			--d2l-note-edit-textarea-padding-horizontal: 0.75rem;
+			--d2l-note-edit-transition-duration: 0.5s;
+		}
+
+		.d2l-note-edit-controls {
+			margin-top: var(--d2l-note-edit-spacing);
+			display: flex;
+			flex-direction: row;
+			justify-content: space-between;
+			flex-wrap: wrap-reverse;
+
+			transition-property: max-height, opacity, visibility;
+			transition-duration: var(--d2l-note-edit-transition-duration), var(--d2l-note-edit-transition-duration);
+			transition-timing-function: ease, ease;
+
+			@apply --d2l-note-edit-controls;
+		}
+
+		.d2l-note-edit-button {
+			margin-right: 0.5rem;
+		}
+
+		:host(:dir(rtl)) .d2l-note-edit-button {
+			margin-right: initial;
+			margin-left: 0.5rem;
+		}
+		:host-context([dir="rtl"]) > .d2l-note-edit-main .d2l-note-edit-button {
+			margin-right: initial;
+			margin-left: 0.5rem;
+		}
+
+		:host(:not([focused])) .d2l-note-edit-controls,
+		:host(:not([expanded])) .d2l-note-edit-controls {
+			max-height: 0;
+			opacity: 0;
+			visibility: hidden;
+
+			transition-delay: var(--d2l-note-edit-transition-duration), 0s, var(--d2l-note-edit-transition-duration);
+
+			@apply --d2l-note-edit-controls-nofocus;
+		}
+
+		:host([focused]) .d2l-note-edit-controls,
+		:host([expanded]) .d2l-note-edit-controls {
+			max-height: 90px;
+			opacity: 1;
+			visibility: visible;
+
+			transition-delay: 0s, var(--d2l-note-edit-transition-duration), var(--d2l-note-edit-transition-duration);
+
+			@apply --d2l-note-edit-controls-focus;
+		}
+
+		.d2l-note-edit-bottom-right {
+			display: flex;
+			flex-direction: row;
+			flex: 1 0 auto;
+			justify-content: space-between;
+
+			@apply --d2l-note-edit-bottom-right;
+		}
+
+		.d2l-note-edit-settings {
+			display: inline-flex;
+			align-items: center;
+
+			@apply --d2l-note-edit-settings;
+		}
+
+		d2l-alert {
+			margin-top: var(--d2l-note-edit-spacing);
+
+			@apply --d2l-note-edit-error-alert;
+		}
+
+		textarea.d2l-input.d2l-note-edit-error {
+			border-color: var(--d2l-alert-critical-color, --d2l-color-cinnabar);
+
+			@apply --d2l-note-edit-error-textarea;
+		}
+
+		textarea.d2l-input {
+			padding: var(--d2l-note-edit-textarea-padding-vertical) var(--d2l-note-edit-textarea-padding-horizontal);
+
+			font-size: var(--d2l-note-edit-textarea-font-size);
+
+			transition-property: height, background-color, border-color;
+			transition-duration: var(--d2l-note-edit-transition-duration), var(--d2l-note-edit-transition-duration), var(--d2l-note-edit-transition-duration);
+			transition-timing-function: ease, ease, ease;
+		}
+
+		:host(:not([focused])) textarea.d2l-input,
+		:host(:not([expanded])) textarea.d2l-input {
+			height: var(--d2l-note-edit-textarea-collapsed-height);
+			transition-delay: var(--d2l-note-edit-transition-duration), 0s, 0s;
+			@apply --d2l-note-edit-textarea-nofocus;
+		}
+
+		:host([focused]) textarea.d2l-input,
+		:host([expanded]) textarea.d2l-input {
+			height: var(--d2l-note-edit-textarea-expanded-height);
+			transition-delay: 0s, 0s, 0s;
+			@apply --d2l-note-edit-textarea-focus;
+		}
+
+		textarea.d2l-input.d2l-note-edit-error:hover,
+		textarea.d2l-input.d2l-note-edit-error:focus {
+			border-color: var(--d2l-color-feedback-error, --d2l-color-cinnabar);
+			border-width: 2px;
+			outline-style: none;
+			outline-width: 0;
+		}
+
+		textarea.d2l-input::placeholder {
+			color: var(--d2l-input-placeholder-color);
+			font-size: var(--d2l-note-edit-textarea-font-size);
+			font-weight: 400;
+			opacity: 1; /* Firefox has non-1 default */
+		}
+
+		textarea.d2l-input:focus {
+			padding: calc(var(--d2l-note-edit-textarea-padding-vertical) - 1px) calc(var(--d2l-note-edit-textarea-padding-horizontal) - 1px);
+		}
+	`];
 
 	connectedCallback() {
 		super.connectedCallback();
@@ -137,8 +271,8 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 
 	updated(changedProps) {
 		super.updated(changedProps);
-		if (changedProps.has('errormessage') && this.errormessage) {
-			announce(this.errormessage);
+		if (changedProps.has('errorMessage') && this.errorMessage) {
+			announce(this.errorMessage);
 		}
 	}
 
@@ -151,145 +285,6 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 		 * the element template.
 		 */
 		return html`
-			<style>
-				:host {
-					display: block;
-					line-height: 0;
-
-					--d2l-note-edit-spacing: 12px;
-					--d2l-note-edit-textarea-font-size: 1rem;
-
-					/* need to set px for transitioning in Edge/IE11 */
-					/* height: calc(var(--d2l-note-edit-textarea-line-height) + var(--d2l-note-edit-textarea-padding-vertical) * 2 + 2px); */
-					--d2l-note-edit-textarea-collapsed-height: 2.3rem;
-					/* height: calc(var(--d2l-note-edit-textarea-line-height) * 4 + var(--d2l-note-edit-textarea-padding-vertical) * 2 + 2px); */
-					--d2l-note-edit-textarea-expanded-height: 95px;
-
-					--d2l-note-edit-textarea-padding-vertical: 0.5rem;
-					--d2l-note-edit-textarea-padding-horizontal: 0.75rem;
-					--d2l-note-edit-transition-duration: 0.5s;
-				}
-
-				.d2l-note-edit-controls {
-					margin-top: var(--d2l-note-edit-spacing);
-					display: flex;
-					flex-direction: row;
-					justify-content: space-between;
-					flex-wrap: wrap-reverse;
-
-					transition-property: max-height, opacity, visibility;
-					transition-duration: var(--d2l-note-edit-transition-duration), var(--d2l-note-edit-transition-duration);
-					transition-timing-function: ease, ease;
-
-					@apply --d2l-note-edit-controls;
-				}
-
-				.d2l-note-edit-button {
-					margin-right: 0.5rem;
-				}
-
-				:host(:dir(rtl)) .d2l-note-edit-button {
-					margin-right: initial;
-					margin-left: 0.5rem;
-				}
-				:host-context([dir="rtl"]) > .d2l-note-edit-main .d2l-note-edit-button {
-					margin-right: initial;
-					margin-left: 0.5rem;
-				}
-
-				:host(:not([focused])) .d2l-note-edit-controls,
-				:host(:not([expanded])) .d2l-note-edit-controls {
-					max-height: 0;
-					opacity: 0;
-					visibility: hidden;
-
-					transition-delay: var(--d2l-note-edit-transition-duration), 0s, var(--d2l-note-edit-transition-duration);
-
-					@apply --d2l-note-edit-controls-nofocus;
-				}
-
-				:host([focused]) .d2l-note-edit-controls,
-				:host([expanded]) .d2l-note-edit-controls {
-					max-height: 90px;
-					opacity: 1;
-					visibility: visible;
-
-					transition-delay: 0s, var(--d2l-note-edit-transition-duration), var(--d2l-note-edit-transition-duration);
-
-					@apply --d2l-note-edit-controls-focus;
-				}
-
-				.d2l-note-edit-bottom-right {
-					display: flex;
-					flex-direction: row;
-					flex: 1 0 auto;
-					justify-content: space-between;
-
-					@apply --d2l-note-edit-bottom-right;
-				}
-
-				.d2l-note-edit-settings {
-					display: inline-flex;
-					align-items: center;
-
-					@apply --d2l-note-edit-settings;
-				}
-
-				d2l-alert {
-					margin-top: var(--d2l-note-edit-spacing);
-
-					@apply --d2l-note-edit-error-alert;
-				}
-
-				textarea.d2l-input.d2l-note-edit-error {
-					border-color: var(--d2l-alert-critical-color, --d2l-color-cinnabar);
-
-					@apply --d2l-note-edit-error-textarea;
-				}
-
-				textarea.d2l-input {
-					padding: var(--d2l-note-edit-textarea-padding-vertical) var(--d2l-note-edit-textarea-padding-horizontal);
-
-					font-size: var(--d2l-note-edit-textarea-font-size);
-
-					transition-property: height, background-color, border-color;
-					transition-duration: var(--d2l-note-edit-transition-duration), var(--d2l-note-edit-transition-duration), var(--d2l-note-edit-transition-duration);
-					transition-timing-function: ease, ease, ease;
-				}
-
-				:host(:not([focused])) textarea.d2l-input,
-				:host(:not([expanded])) textarea.d2l-input {
-					height: var(--d2l-note-edit-textarea-collapsed-height);
-					transition-delay: var(--d2l-note-edit-transition-duration), 0s, 0s;
-					@apply --d2l-note-edit-textarea-nofocus;
-				}
-
-				:host([focused]) textarea.d2l-input,
-				:host([expanded]) textarea.d2l-input {
-					height: var(--d2l-note-edit-textarea-expanded-height);
-					transition-delay: 0s, 0s, 0s;
-					@apply --d2l-note-edit-textarea-focus;
-				}
-
-				textarea.d2l-input.d2l-note-edit-error:hover,
-				textarea.d2l-input.d2l-note-edit-error:focus {
-					border-color: var(--d2l-color-feedback-error, --d2l-color-cinnabar);
-					border-width: 2px;
-					outline-style: none;
-					outline-width: 0;
-				}
-
-				textarea.d2l-input::placeholder {
-					color: var(--d2l-input-placeholder-color);
-					font-size: var(--d2l-note-edit-textarea-font-size);
-					font-weight: 400;
-					opacity: 1; /* Firefox has non-1 default */
-				}
-
-				textarea.d2l-input:focus {
-					padding: calc(var(--d2l-note-edit-textarea-padding-vertical) - 1px) calc(var(--d2l-note-edit-textarea-padding-horizontal) - 1px);
-				}
-			</style>
 			<div class="d2l-note-edit-description">
 				<slot name="description"></slot>
 			</div>
@@ -298,13 +293,13 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 				@focusin=${this._handleFocusin}
 			>
 				<textarea
-					class="d2l-input ${this.errormessage ? 'd2l-note-edit-error' : ''}"
+					class="d2l-input ${this.errorMessage ? 'd2l-note-edit-error' : ''}"
 					.value=${this.value}
 					placeholder="${this.placeholder}"
 					@input=${this._handleInput}
 					?disabled="${this._makingCall}"
 				></textarea>
-				<d2l-alert role="alert" type="critical" .hidden=${!this.errormessage}>${this.errormessage}</d2l-alert>
+				<d2l-alert role="alert" type="critical" .hidden=${!this.errorMessage}>${this.errorMessage}</d2l-alert>
 				<div class="d2l-note-edit-controls">
 					<d2l-button
 						class="d2l-note-edit-button"
@@ -312,13 +307,15 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 						@click=${this._handleEditClick}
 						?disabled="${this._makingCall}"
 					>
-						${this.new ? this.addnotestring ? this.addnotestring : this.localize('add') : this.savenotestring ? this.savenotestring : this.localize('save')}
+						${this.new ? this.addNoteString ? this.addNoteString : this.localize('add') : this.saveNoteString ? this.saveNoteString : this.localize('save')}
 					</d2l-button>
 					<div class="d2l-note-edit-bottom-right">
 						<d2l-button
-						class="d2l-note-edit-discard-button"
-						@click=${this._handleClick}
-						>${this.discardnotestring ? this.discardnotestring : this.localize('cancel')}</d2l-button>
+							class="d2l-note-edit-discard-button"
+							@click=${this._handleClick}
+						>
+							${this.discardNoteString ? this.discardNoteString : this.localize('cancel')}
+						</d2l-button>
 						<div class="d2l-note-edit-settings">
 							<slot name="settings"></slot>
 						</div>
@@ -333,11 +330,11 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 	}
 
 	_handleEditClick() {
-		this.errormessage = undefined;
+		this.errorMessage = undefined;
 		const finish = (error) => {
 			this._makingCall = false;
 			if (error) {
-				this.errormessage = error.message ? error.message : error;
+				this.errorMessage = error.message ? error.message : error;
 				return;
 			}
 			this.dispatchEvent(new CustomEvent(this.EVENT_FINISHED, {
@@ -381,7 +378,7 @@ export class D2LNoteEdit extends LocalizeMixin(LitElement) {
 	}
 
 	_handleClick() {
-		this.errormessage = undefined;
+		this.errorMessage = undefined;
 		const discarded = this.dispatchEvent(new CustomEvent(this.EVENT_DISCARD, {
 			bubbles: true,
 			composed: true,

--- a/src/d2l-note.js
+++ b/src/d2l-note.js
@@ -14,13 +14,13 @@ import './d2l-note-edit';
  * Import LitElement base class, html helper function,
  * and TypeScript decorators
  **/
-import { html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 
 import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { formatDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
 import { langResources } from './lang';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { repeat } from 'lit-html/directives/repeat';
+import { repeat } from 'lit/directives/repeat.js';
 
 /**
  * d2l-note component created with lit-element
@@ -56,109 +56,107 @@ import { repeat } from 'lit-html/directives/repeat';
  */
 export class D2LNote extends LocalizeMixin(LitElement) {
 
-	static get properties() {
-		return {
-			/**
-			 * Username and avatar to show
-			 * user.pic.url = <avatar url>
-			 * user.pic.requireTokenAuth <true/false>
-			 * user.name = <user name to show>
-			 */
-			user: { type: Object },
-			/**
-			 * Token to use in request when user.pic.requireTokenAuth is true
-			 */
-			token: { type: String },
-			/**
-			 * show avatar and username if true
-			 */
-			showavatar: { type: Boolean },
-			/**
-			 * Compact view. Removes padding
-			 */
-			compact: { type: Boolean },
-			/**
-			 * ISO datetime string of note creation
-			 */
-			createdat: { type: String },
-			/**
-			 * ISO datetime string of note update
-			 */
-			updatedat: { type: String },
-			/**
-			 * Text of note
-			 */
-			text: { type: String},
-			/**
-			 * d2l-note-edit placeholder to show when editing
-			 */
-			editplaceholder: { type: String },
-			/**
-			 * Indicates note user is the current user
-			 */
-			me: { type: Boolean },
-			/**
-			 * Indicates this note is private
-			 */
-			private: { type: Boolean, reflect: true },
-			/**
-			 * Indicates this note can be edited by the current user
-			 */
-			canedit: { type: Boolean },
-			/**
-			 * Indicates this note can be deleted by the current user
-			 */
-			candelete: { type: Boolean },
-			/**
-			 * value for "format" property of @brightspace-ui/intl formatDateTime options
-			 */
-			dateformat: { type: String },
-			/**
-			 * Indicates whether the note is beting edited
-			 * Shows a d2l-note-edit component if true
-			 */
-			editing: { type: String },
-			/**
-			* Label for the edit/delete context menu
-			*/
-			contextmenulabel: { type: String },
-			/**
-			 * Label of edit menu item
-			 */
-			editstring: { type: String },
-			/**
-			 * Label of delete menu item
-			 */
-			deletestring: { type: String },
-			/**
-			 * Label of private indicator
-			 */
-			privatelabel: { type: String },
-			/**
-			 * Text of 'Add' button in d2l-note-edit
-			 */
-			addnotestring: { type: String },
-			/**
-			 * Text of 'Save' button in d2l-note-edit
-			 */
-			savenotestring: { type: String },
-			/**
-			 * Label of 'Discard' button in d2l-note-edit
-			 */
-			discardnotestring: { type: String },
-		};
+	static properties = {
+		/**
+		 * Username and avatar to show
+		 * user.pic.url = <avatar url>
+		 * user.pic.requireTokenAuth <true/false>
+		 * user.name = <user name to show>
+		 */
+		user: { type: Object },
+		/**
+		 * Token to use in request when user.pic.requireTokenAuth is true
+		 */
+		token: { type: String },
+		/**
+	 * show avatar and username if true
+	 */
+		showAvatar: { type: Boolean, attribute: 'show-avatar' },
+		/**
+		 * Compact view. Removes padding
+		 */
+		compact: { type: Boolean },
+		/**
+		 * ISO datetime string of note creation
+		 */
+		createdAt: { type: String, attribute: 'created-at' },
+		/**
+		 * ISO datetime string of note update
+		 */
+		updatedAt: { type: String, attribute: 'updated-at' },
+		/**
+		 * Text of note
+		 */
+		text: { type: String },
+		/**
+		 * d2l-note-edit placeholder to show when editing
+		 */
+		editPlaceholder: { type: String, attribute: 'edit-placeholder' },
+		/**
+		 * Indicates note user is the current user
+		 */
+		me: { type: Boolean },
+		/**
+		 * Indicates this note is private
+		 */
+		private: { type: Boolean, reflect: true },
+		/**
+		 * Indicates this note can be edited by the current user
+		 */
+		canEdit: { type: Boolean, attribute: 'can-edit' },
+		/**
+		 * Indicates this note can be deleted by the current user
+		 */
+		canDelete: { type: Boolean, attribute: 'can-delete' },
+		/**
+		 * value for "format" property of @brightspace-ui/intl formatDateTime options
+		 */
+		dateFormat: { type: String, attribute: 'date-format' },
+		/**
+		 * Indicates whether the note is beting edited
+		 * Shows a d2l-note-edit component if true
+		 */
+		editing: { type: String },
+		/**
+		* Label for the edit/delete context menu
+		*/
+		contextMenuLabel: { type: String, attribute: 'context-menu-label' },
+		/**
+		 * Label of edit menu item
+		 */
+		editString: { type: String, attribute: 'edit-string' },
+		/**
+		 * Label of delete menu item
+		 */
+		deleteString: { type: String, attribute: 'delete-string' },
+		/**
+		 * Label of private indicator
+		 */
+		privateLabel: { type: String, attribute: 'private-label' },
+		/**
+		 * Text of 'Add' button in d2l-note-edit
+		 */
+		addNoteString: { type: String, attribute: 'add-note-string' },
+		/**
+		 * Text of 'Save' button in d2l-note-edit
+		 */
+		saveNoteString: { type: String, attribute: 'save-note-string' },
+		/**
+		 * Label of 'Discard' button in d2l-note-edit
+		 */
+		discardNoteString: { type: String, attribute: 'discard-note-string' },
 	}
 
 	constructor() {
 		super();
-		this.showavatar = false;
+		this.showAvatar = false;
 		this.compact = false;
-		this.editplaceholder = '';
+		this.editPlaceholder = '';
 		this.me = false;
 		this.private = false;
-		this.canedit = false;
-		this.candelete = false;
-		this.dateformat = 'medium';
+		this.canEdit = false;
+		this.canDelete = false;
+		this.dateFormat = 'medium';
 		this.editing = false;
 
 		/**
@@ -179,9 +177,163 @@ export class D2LNote extends LocalizeMixin(LitElement) {
 		}
 	}
 
-	static get styles() {
-		return bodyStandardStyles;
-	}
+	static styles = [bodyStandardStyles, css`
+		:host {
+			--d2l-note-user-text-spacing: 12px;
+			--d2l-note-paragraph-spacing: 0.5rem;
+			--d2l-note-padding-vertical: 0.5rem;
+			--d2l-note-padding-horizontal: 1rem;
+			--d2l-note-margin-horizontal: -1rem;
+
+			--d2l-note-local-context-menu-rtl: {
+				@apply --d2l-note-context-menu-rtl;
+			};
+
+			--d2l-note-local-private-indicator-rtl: {
+				@apply --d2l-note-private-indicator-rtl;
+			};
+		}
+		:host([compact]) {
+			--d2l-note-user-text-spacing: 8px;
+			--d2l-note-padding-vertical: 0;
+			--d2l-note-padding-horizontal: 0;
+			--d2l-note-margin-horizontal: 0;
+		}
+		:host {
+			position: relative;
+			display: flex;
+			line-height: 0;
+			padding: var(--d2l-note-padding-vertical) var(--d2l-note-padding-horizontal);
+			margin: 0 var(--d2l-note-margin-horizontal);
+		}
+		:host([private]) {
+			background-color: var(--d2l-color-regolith);
+		}
+		.d2l-note-main {
+			flex: 1;
+			line-height: 0;
+			max-width: 100%;
+			position: relative;
+		}
+		.d2l-note-top {
+			display: flex;
+			justify-content: space-between;
+			align-items: flex-start;
+		}
+
+		d2l-user {
+			margin-bottom: var(--d2l-note-user-text-spacing);
+
+			@apply --d2l-note-user;
+		}
+
+		.d2l-note-text {
+			position: relative;
+			max-width: 100%;
+
+			@apply --d2l-note-text;
+		}
+		.paragraph {
+			margin: var(--d2l-note-paragraph-spacing) 0;
+			word-break: break-word; /* Not universally supported */
+			word-wrap: break-word;  /* Alternate for above */
+			overflow-wrap: anywhere; /* Overrides word-* rules, where supported */
+
+			@apply --d2l-note-paragraph;
+		}
+		.paragraph.first {
+			margin-top: 0;
+		}
+		.paragraph.last {
+			margin-bottom: 0;
+		}
+
+		d2l-dropdown-more {
+			@apply --d2l-note-context-menu;
+		}
+
+		:host(:dir(rtl)) d2l-dropdown-more {
+			@apply --d2l-note-local-context-menu-rtl;
+		}
+		:host-context([dir="rtl"]) > .d2l-note-main d2l-dropdown-more {
+			@apply --d2l-note-local-context-menu-rtl;
+		}
+
+		.d2l-note-private-indicator {
+			margin: 8px;
+			@apply --d2l-note-private-indicator;
+		}
+
+		:host(:dir(rtl)) .d2l-note-private-indicator {
+			@apply --d2l-note-local-private-indicator-rtl;
+		}
+		:host-context([dir="rtl"]) > .d2l-note-main .d2l-note-private-indicator {
+			@apply --d2l-note-local-private-indicator-rtl;
+		}
+
+		.d2l-note-text-container {
+			display: flex;
+			position: relative;
+			max-width: 100%;
+		}
+
+		d2l-more-less {
+			flex: 1;
+			position: relative;
+			max-width: 100%;
+		}
+
+		d2l-note-edit {
+			flex: 1;
+		}
+
+		.skeleton {
+			background: var(--d2l-color-sylvite);
+			border-radius: 6px;
+			@apply --d2l-note-skeleton;
+		}
+
+		.skeleton.skeleton-avatar {
+			width: 42px;
+			height: 42px;
+		}
+
+		.skeleton-user {
+			display: flex;
+			justify-content: space-between;
+			width: 197px;
+			margin-bottom: var(--d2l-note-user-text-spacing);
+
+			@apply --d2l-note-user;
+			@apply --d2l-note-skeleton-user;
+		}
+
+		.skeleton-user .skeleton-info-container {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+		}
+
+		.skeleton-user .skeleton-name {
+			width: 80px;
+			/* 20px = user name/subtext line height */
+			height: 20px;
+			margin-bottom: 5px;
+		}
+
+		.skeleton-user .skeleton-subtext {
+			width: 140px;
+			height: 20px;
+		}
+
+		.d2l-note-text-skeleton {
+			@apply --d2l-body-standard-text;
+			width: 100%;
+
+			@apply --d2l-note-text;
+			@apply --d2l-note-skeleton-text;
+		}
+	`];
 
 	/**
 	 * Implement `render` to define a template for your element.
@@ -204,173 +356,16 @@ export class D2LNote extends LocalizeMixin(LitElement) {
 		 * Use JavaScript expressions to include property values in
 		 * the element template.
 		 */
-		const imageUrl = (this.showavatar && this.user && this.user.pic) ? this.user.pic.url : undefined;
-		const useImageAuthentication = !!(this.showavatar && this.user && this.user.pic && this.user.pic.requireTokenAuth);
-		const userName = this.showavatar ? this.me ? this.localize('me') : this.user ? this.user.name : undefined : undefined;
+		const imageUrl = (this.showAvatar && this.user && this.user.pic) ? this.user.pic.url : undefined;
+		const useImageAuthentication = !!(this.showAvatar && this.user && this.user.pic && this.user.pic.requireTokenAuth);
+		const userName = this.showAvatar ? this.me ? this.localize('me') : this.user ? this.user.name : undefined : undefined;
 
-		const createdAtDate = this.createdat ? new Date(this.createdat) : null;
-		const dateTime = createdAtDate ? formatDateTime(createdAtDate, { format: this.dateformat || 'medium' }) : undefined;
+		const createdAtDate = this.createdAt ? new Date(this.createdAt) : null;
+		const dateTime = createdAtDate ? formatDateTime(createdAtDate, { format: this.dateFormat || 'medium' }) : undefined;
 
-		const subText = dateTime ? this.updatedat ? this.localize('subtextEdited', { '0': dateTime }) : dateTime : '';
-		const showDropdown = this.canedit || this.candelete;
+		const subText = dateTime ? this.updatedAt ? this.localize('subtextEdited', { '0': dateTime }) : dateTime : '';
+		const showDropdown = this.canEdit || this.canDelete;
 		return html`
-			<style>
-				:host {
-					--d2l-note-user-text-spacing: 12px;
-					--d2l-note-paragraph-spacing: 0.5rem;
-					--d2l-note-padding-vertical: 0.5rem;
-					--d2l-note-padding-horizontal: 1rem;
-					--d2l-note-margin-horizontal: -1rem;
-
-					--d2l-note-local-context-menu-rtl: {
-						@apply --d2l-note-context-menu-rtl;
-					};
-
-					--d2l-note-local-private-indicator-rtl: {
-						@apply --d2l-note-private-indicator-rtl;
-					};
-				}
-				:host([compact]) {
-					--d2l-note-user-text-spacing: 8px;
-					--d2l-note-padding-vertical: 0;
-					--d2l-note-padding-horizontal: 0;
-					--d2l-note-margin-horizontal: 0;
-				}
-				:host {
-					position: relative;
-					display: flex;
-					line-height: 0;
-					padding: var(--d2l-note-padding-vertical) var(--d2l-note-padding-horizontal);
-					margin: 0 var(--d2l-note-margin-horizontal);
-				}
-				:host([private]) {
-					background-color: var(--d2l-color-regolith);
-				}
-				.d2l-note-main {
-					flex: 1;
-					line-height: 0;
-					max-width: 100%;
-					position: relative;
-				}
-				.d2l-note-top {
-					display: flex;
-					justify-content: space-between;
-					align-items: flex-start;
-				}
-
-				d2l-user {
-					margin-bottom: var(--d2l-note-user-text-spacing);
-
-					@apply --d2l-note-user;
-				}
-
-				.d2l-note-text {
-					position: relative;
-					max-width: 100%;
-
-					@apply --d2l-note-text;
-				}
-				.paragraph {
-					margin: var(--d2l-note-paragraph-spacing) 0;
-					word-break: break-word; /* Not universally supported */
-					word-wrap: break-word;  /* Alternate for above */
-					overflow-wrap: anywhere; /* Overrides word-* rules, where supported */
-
-					@apply --d2l-note-paragraph;
-				}
-				.paragraph.first {
-					margin-top: 0;
-				}
-				.paragraph.last {
-					margin-bottom: 0;
-				}
-
-				d2l-dropdown-more {
-					@apply --d2l-note-context-menu;
-				}
-
-				:host(:dir(rtl)) d2l-dropdown-more {
-					@apply --d2l-note-local-context-menu-rtl;
-				}
-				:host-context([dir="rtl"]) > .d2l-note-main d2l-dropdown-more {
-					@apply --d2l-note-local-context-menu-rtl;
-				}
-
-				.d2l-note-private-indicator {
-					margin: 8px;
-					@apply --d2l-note-private-indicator;
-				}
-
-				:host(:dir(rtl)) .d2l-note-private-indicator {
-					@apply --d2l-note-local-private-indicator-rtl;
-				}
-				:host-context([dir="rtl"]) > .d2l-note-main .d2l-note-private-indicator {
-					@apply --d2l-note-local-private-indicator-rtl;
-				}
-
-				.d2l-note-text-container {
-					display: flex;
-					position: relative;
-					max-width: 100%;
-				}
-
-				d2l-more-less {
-					flex: 1;
-					position: relative;
-					max-width: 100%;
-				}
-
-				d2l-note-edit {
-					flex: 1;
-				}
-
-				.skeleton {
-					background: var(--d2l-color-sylvite);
-					border-radius: 6px;
-					@apply --d2l-note-skeleton;
-				}
-
-				.skeleton.skeleton-avatar {
-					width: 42px;
-					height: 42px;
-				}
-
-				.skeleton-user {
-					display: flex;
-					justify-content: space-between;
-					width: 197px;
-					margin-bottom: var(--d2l-note-user-text-spacing);
-
-					@apply --d2l-note-user;
-					@apply --d2l-note-skeleton-user;
-				}
-
-				.skeleton-user .skeleton-info-container {
-					display: flex;
-					flex-direction: column;
-					justify-content: center;
-				}
-
-				.skeleton-user .skeleton-name {
-					width: 80px;
-					/* 20px = user name/subtext line height */
-					height: 20px;
-					margin-bottom: 5px;
-				}
-
-				.skeleton-user .skeleton-subtext {
-					width: 140px;
-					height: 20px;
-				}
-
-				.d2l-note-text-skeleton {
-					@apply --d2l-body-standard-text;
-					width: 100%;
-
-					@apply --d2l-note-text;
-					@apply --d2l-note-skeleton-text;
-				}
-			</style>
 			<div class="d2l-note-main d2l-typography">
 				<div class="d2l-note-top">
 					${this.user ? html`
@@ -380,57 +375,72 @@ export class D2LNote extends LocalizeMixin(LitElement) {
 							.name="${userName}"
 							.subText="${subText}"
 							.useImageAuthentication=${useImageAuthentication}
-							.shouldHideImage=${!this.showavatar}
-							>${this.user.href ? html`<d2l-profile-image
+							.shouldHideImage=${!this.showAvatar}
+						>
+							${this.user.href ? html`
+								<d2l-profile-image
 									slot="avatar"
 									href="${this.user.href}"
 									token="${this.token}"
 									medium
-								></d2l-profile-image>` : null }</d2l-user>` : html`
+								></d2l-profile-image>
+							` : null}
+						</d2l-user>
+					` : html`
 						<div class="d2l-note-user-skeleton skeleton-user">
 							<div class="skeleton skeleton-avatar"></div>
 							<div class="skeleton-info-container">
 								<div class="skeleton skeleton-name"></div>
 								<div class="skeleton skeleton-subtext"></div>
 							</div>
-						</div>`}
+						</div>
+					`}
 					${showDropdown ? html`
-						<d2l-dropdown-more text="${this.contextmenulabel ? this.contextmenulabel : this.localize('contextMenu')}">
+						<d2l-dropdown-more text="${this.contextMenuLabel ? this.contextMenuLabel : this.localize('contextMenu')}">
 							<d2l-dropdown-menu>
-								<d2l-menu label="${this.contextmenulabel ? this.contextmenulabel : this.localize('contextMenu')}">
-									${this.canedit && !this.editing ? html`<d2l-menu-item
-										text="${this.editstring ? this.editstring : this.localize('edit')}"
-										@d2l-menu-item-select=${this.editSelectHandler}
-									></d2l-menu-item>` : null }
-									${this.candelete ? html`<d2l-menu-item
-										text="${this.deletestring ? this.deletestring : this.localize('delete')}"
-										@d2l-menu-item-select=${this.deleteSelectHandler}
-									></d2l-menu-item>` : null }
+								<d2l-menu label="${this.contextMenuLabel ? this.contextMenuLabel : this.localize('contextMenu')}">
+									${this.canEdit && !this.editing ? html`
+										<d2l-menu-item
+											text="${this.editString ? this.editString : this.localize('edit')}"
+											@d2l-menu-item-select=${this.editSelectHandler}
+										></d2l-menu-item>
+									` : null}
+									${this.canDelete ? html`
+										<d2l-menu-item
+											text="${this.deleteString ? this.deleteString : this.localize('delete')}"
+											@d2l-menu-item-select=${this.deleteSelectHandler}
+										></d2l-menu-item>
+									` : null }
 								</d2l-menu>
 							</d2l-dropdown-menu>
-						</d2l-dropdown-more>` : null }
+						</d2l-dropdown-more>
+					` : null }
 				</div>
 				<div class="d2l-note-text-container">
 					${this.editing ? html`
 						<d2l-note-edit
 							id="${this.id}"
-							placeholder="${this.editplaceholder}"
+							placeholder="${this.editPlaceholder}"
 							value="${this.text}"
 							expanded
-							.addnotestring=${this.addnotestring}
-							.savenotestring=${this.savenotestring}
-							.discardnotestring=${this.discardnotestring}
+							.addnotestring=${this.addNoteString}
+							.savenotestring=${this.saveNoteString}
+							.discardnotestring=${this.discardNoteString}
 							@d2l-note-edit-finished=${this._handleFinished}
 						>
 							<slot name="description" slot="description"></slot>
 							<slot name="settings" slot="settings"></slot>
-						</d2l-note-edit>` : this.text ? convertText(this.text) : html`
-						<div class="d2l-note-text-skeleton skeleton">&nbsp;</div>`}
-					${!this.editing && this.private ? html`<d2l-icon
-						class="d2l-note-private-indicator"
-						icon="d2l-tier1:visibility-hide"
-						aria-label="${this.privatelabel ? this.privatelabel : this.localize('private')}"
-					></d2l-icon>` : null }
+						</d2l-note-edit>
+					` : this.text ? convertText(this.text) : html`
+						<div class="d2l-note-text-skeleton skeleton">&nbsp;</div>
+					`}
+					${!this.editing && this.private ? html`
+						<d2l-icon
+							class="d2l-note-private-indicator"
+							icon="d2l-tier1:visibility-hide"
+							aria-label="${this.privateLabel ? this.privateLabel : this.localize('private')}"
+						></d2l-icon>
+					` : null }
 				</div>
 			</div>
 		`;

--- a/src/d2l-note.js
+++ b/src/d2l-note.js
@@ -423,9 +423,9 @@ export class D2LNote extends LocalizeMixin(LitElement) {
 							placeholder="${this.editPlaceholder}"
 							value="${this.text}"
 							expanded
-							.addnotestring=${this.addNoteString}
-							.savenotestring=${this.saveNoteString}
-							.discardnotestring=${this.discardNoteString}
+							add-note-string=${this.addNoteString}
+							save-note-string=${this.saveNoteString}
+							discard-note-string=${this.discardNoteString}
 							@d2l-note-edit-finished=${this._handleFinished}
 						>
 							<slot name="description" slot="description"></slot>

--- a/src/d2l-note.js
+++ b/src/d2l-note.js
@@ -69,8 +69,8 @@ export class D2LNote extends LocalizeMixin(LitElement) {
 		 */
 		token: { type: String },
 		/**
-	 * show avatar and username if true
-	 */
+		 * show avatar and username if true
+		 */
 		showAvatar: { type: Boolean, attribute: 'show-avatar' },
 		/**
 		 * Compact view. Removes padding

--- a/src/d2l-notes.js
+++ b/src/d2l-notes.js
@@ -62,8 +62,8 @@ export class D2LNotes extends LocalizeMixin(LitElement) {
 		 */
 		notes: { type: Array },
 		/**
-* Indicates this user can create new notes
-*/
+		 * Indicates this user can create new notes
+		 */
 		canCreate: { type: Boolean, attribute: 'can-create' },
 		/**
 		 * d2l-note-edit placeholder to show when creating

--- a/src/d2l-notes.js
+++ b/src/d2l-notes.js
@@ -6,12 +6,11 @@ import './d2l-note';
  * Import LitElement base class, html helper function,
  * and TypeScript decorators
  **/
-import { html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 
 import { bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { langResources } from './lang';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { repeat } from 'lit-html/directives/repeat';
 
 /**
  * d2l-note component created with lit-element
@@ -57,97 +56,95 @@ import { repeat } from 'lit-html/directives/repeat';
  * ```
  */
 export class D2LNotes extends LocalizeMixin(LitElement) {
-	static get properties() {
-		return {
-			/**
-			 * Array of notes to pass to d2l-note elements
-			 */
-			notes: { type: Array },
-			/**
-			 * Indicates this user can create new notes
-			 */
-			cancreate: { type: Boolean },
-			/**
-			 * d2l-note-edit placeholder to show when creating
-			 */
-			editplaceholder: { type: String },
-			/**
-			 * TemplateResult containing description for d2l-note's in edit state and d2l-note-edit
-			 */
-			description: { type: Object },
-			/**
-			 * TemplateResult containing settings for d2l-note's in edit state and d2l-note-edit
-			 */
-			settings: { type: Object },
-			/**
-			 * Show the loadmore button regardless of number of items
-			 */
-			hasmore: { type: Boolean },
-			/**
-			 * Load more/less collapsed state
-			 */
-			collapsed: { type: Boolean },
-			/**
-			 * Number of items to show before showing the load more button
-			 */
-			collapsedsize: { type: Number },
-			/**
-			 * dateformat in d2l-note's
-			 */
-			dateformat: { type: String },
-			/**
-			 * override loadmore button text
-			 */
-			loadmorestring: { type: String },
-			/**
-			 * override loadless button text
-			 */
-			loadlessstring: { type: String },
-			/**
-			 * editstring in d2l-note's
-			 */
-			editstring: { type: String },
-			/**
-			 * deletestring in d2l-note's
-			 */
-			deletestring: { type: String },
-			/**
-			 * privatelabel in d2l-note's
-			 */
-			privatelabel: { type: String },
-			/**
-			 * addnotestring in d2l-note-edit
-			 */
-			addnotestring: { type: String },
-			/**
-			 * savenotestring in d2l-note's
-			 */
-			savenotestring: { type: String },
-			/**
-			 * discardnotestring in d2l-note's and d2l-note-edit
-			 */
-			discardnotestring: { type: String },
-			/**
-			 * string to show when there are no notes to show. Set to '' to not show anything
-			 */
-			emptystring: { type: String },
-			/**
-			 * label for the 'enter notes' area, overridden by emptystring if there are no existing notes. Does not render if undefined
-			 */
-			enternotestring: { type: String },
-		};
+	static properties = {
+		/**
+		 * Array of notes to pass to d2l-note elements
+		 */
+		notes: { type: Array },
+		/**
+* Indicates this user can create new notes
+*/
+		canCreate: { type: Boolean, attribute: 'can-create' },
+		/**
+		 * d2l-note-edit placeholder to show when creating
+		 */
+		editPlaceholder: { type: String, attribute: 'edit-placeholder' },
+		/**
+		 * TemplateResult containing description for d2l-note's in edit state and d2l-note-edit
+		 */
+		description: { type: Object },
+		/**
+		 * TemplateResult containing settings for d2l-note's in edit state and d2l-note-edit
+		 */
+		settings: { type: Object },
+		/**
+		 * Show the loadmore button regardless of number of items
+		 */
+		hasMore: { type: Boolean, attribute: 'has-more' },
+		/**
+		 * Load more/less collapsed state
+		 */
+		collapsed: { type: Boolean },
+		/**
+		 * Number of items to show before showing the load more button
+		 */
+		collapsedSize: { type: Number, attribute: 'collapsed-size' },
+		/**
+		 * dateformat in d2l-note's
+		 */
+		dateFormat: { type: String, attribute: 'date-format' },
+		/**
+		 * override loadmore button text
+		 */
+		loadMoreString: { type: String, attribute: 'load-more-string' },
+		/**
+		 * override loadless button text
+		 */
+		loadLessString: { type: String, attribute: 'load-less-string' },
+		/**
+		 * editstring in d2l-note's
+		 */
+		editString: { type: String, attribute: 'edit-string' },
+		/**
+		 * deletestring in d2l-note's
+		 */
+		deleteString: { type: String, attribute: 'delete-string' },
+		/**
+		 * privatelabel in d2l-note's
+		 */
+		privateLabel: { type: String, attribute: 'private-label' },
+		/**
+		 * addnotestring in d2l-note-edit
+		 */
+		addNoteString: { type: String, attribute: 'add-note-string' },
+		/**
+		 * savenotestring in d2l-note's
+		 */
+		saveNoteString: { type: String, attribute: 'save-note-string' },
+		/**
+		 * discardnotestring in d2l-note's and d2l-note-edit
+		 */
+		discardNoteString: { type: String, attribute: 'discard-note-string' },
+		/**
+		 * string to show when there are no notes to show. Set to '' to not show anything
+		 */
+		emptyString: { type: String, attribute: 'empty-string' },
+		/**
+		 * label for the 'enter notes' area, overridden by emptystring if there are no existing notes. Does not render if undefined
+		 */
+		enterNoteString: { type: String, attribute: 'enter-note-string' },
 	}
 
 	constructor() {
 		super();
 		this.notes = [];
-		this.cancreate = false;
-		this.editplaceholder = '';
+		this.canCreate = false;
+		this.editPlaceholder = '';
 		this.description = () => html`<div></div>`;
 		this.settings = () => html`<div></div>`;
-		this.hasmore = false;
+		this.hasMore = false;
 		this.collapsed = true;
-		this.collapsedsize = 4;
+		this.collapsedSize = 4;
 
 		/**
 		 * Fired when load more is tapped
@@ -174,154 +171,156 @@ export class D2LNotes extends LocalizeMixin(LitElement) {
 		}
 	}
 
-	static get styles() {
-		return bodyStandardStyles;
-	}
+	static styles = [bodyStandardStyles, css`
+		:host {
+			--d2l-notes-note-margin-top: 6px;
+			--d2l-notes-note-margin-bottom: 12px;
+			--d2l-notes-hr-margin-bottom: 18px;
+			--d2l-notes-ol-margin-bottom: 24px;
+			--d2l-notes-load-more-margin-bottom: 36px;
+		}
+		:host {
+			display: block;
+		}
+		.d2l-typography {
+			line-height: 0;
+		}
+		ol {
+			margin: 0;
+			padding: 0;
+			/* (paragraph separation) 8px + (load more/less border) 1px + (load more/less padding) 8px = 17px */
+			margin-bottom: calc(var(--d2l-notes-ol-margin-bottom) - 17px);
+
+			@apply --d2l-notes-ol;
+		}
+		li {
+			display: block;
+			margin-top: var(--d2l-notes-note-margin-top);
+			margin-bottom: var(--d2l-notes-note-margin-bottom);
+
+			@apply --d2l-notes-li;
+		}
+		li:first-child {
+			margin-top: 0;
+
+			@apply --d2l-notes-li-first;
+		}
+		li:last-child {
+			margin-bottom: 0;
+
+			@apply --d2l-notes-li-last;
+		}
+
+		hr {
+			/* (paragraph separation) 8px */
+			margin-top: calc(var(--d2l-notes-ol-margin-bottom) - 8px);
+			margin-bottom: var(--d2l-notes-hr-margin-bottom);
+
+			@apply --d2l-notes-hr;
+		}
+
+		.d2l-notes-more-less {
+			display: flex;
+			width: 100%;
+			align-items: center;
+			/* load more/less padding (8px) - load more/less border (1px) = 9px */
+			margin-bottom: calc(var(--d2l-notes-load-more-margin-bottom) - 9px);
+
+			@apply --d2l-notes-more-less;
+		}
+
+		.d2l-notes-load-more-less {
+			flex: 0 1 auto;
+
+			@apply --d2l-notes-more-less-button;
+		}
+
+		.d2l-notes-more-less-separator {
+			flex: 1;
+			border-top: solid 1px var(--d2l-color-celestine);
+
+			@apply --d2l-notes-more-less-separator;
+		}
+
+		.d2l-notes-enter-note-string,
+		.d2l-note-emptystring {
+			line-height: 1.4;
+			margin-bottom: 0.6rem;
+		}
+	`];
 
 	/**
 	 * Implement `render` to define a template for your element.
 	 */
 	render() {
-		const hasmore = this.hasmore || this.notes.length > this.collapsedsize;
-		const notes = this.notes && this.collapsed ? this.notes.slice(0, this.collapsedsize) : this.notes;
+		const hasmore = this.hasMore || this.notes.length > this.collapsedSize;
+		const notes = this.notes && this.collapsed ? this.notes.slice(0, this.collapsedSize) : this.notes;
 		/**
 		 * Use JavaScript expressions to include property values in
 		 * the element template.
 		 */
 		return html`
-			<style>
-				:host {
-					--d2l-notes-note-margin-top: 6px;
-					--d2l-notes-note-margin-bottom: 12px;
-					--d2l-notes-hr-margin-bottom: 18px;
-					--d2l-notes-ol-margin-bottom: 24px;
-					--d2l-notes-load-more-margin-bottom: 36px;
-				}
-				:host {
-					display: block;
-				}
-				.d2l-typography {
-					line-height: 0;
-				}
-				ol {
-					margin: 0;
-					padding: 0;
-					/* (paragraph separation) 8px + (load more/less border) 1px + (load more/less padding) 8px = 17px */
-					margin-bottom: calc(var(--d2l-notes-ol-margin-bottom) - 17px);
-
-					@apply --d2l-notes-ol;
-				}
-				li {
-					display: block;
-					margin-top: var(--d2l-notes-note-margin-top);
-					margin-bottom: var(--d2l-notes-note-margin-bottom);
-
-					@apply --d2l-notes-li;
-				}
-				li:first-child {
-					margin-top: 0;
-
-					@apply --d2l-notes-li-first;
-				}
-				li:last-child {
-					margin-bottom: 0;
-
-					@apply --d2l-notes-li-last;
-				}
-
-				hr {
-					/* (paragraph separation) 8px */
-					margin-top: calc(var(--d2l-notes-ol-margin-bottom) - 8px);
-					margin-bottom: var(--d2l-notes-hr-margin-bottom);
-
-					@apply --d2l-notes-hr;
-				}
-
-				.d2l-notes-more-less {
-					display: flex;
-					width: 100%;
-					align-items: center;
-					/* load more/less padding (8px) - load more/less border (1px) = 9px */
-					margin-bottom: calc(var(--d2l-notes-load-more-margin-bottom) - 9px);
-
-					@apply --d2l-notes-more-less;
-				}
-
-				.d2l-notes-load-more-less {
-					flex: 0 1 auto;
-
-					@apply --d2l-notes-more-less-button;
-				}
-
-				.d2l-notes-more-less-separator {
-					flex: 1;
-					border-top: solid 1px var(--d2l-color-celestine);
-
-					@apply --d2l-notes-more-less-separator;
-				}
-
-				.d2l-notes-enter-note-string,
-				.d2l-note-emptystring {
-					line-height: 1.4;
-					margin-bottom: 0.6rem;
-				}
-			</style>
 			<div class="d2l-typography">
 				${notes.length > 0 ? html`
-					<ol>${repeat(notes, (note) => html`
-						<li>
-							<d2l-note
-								.id=${note.id ? note.id : ''}
-								.user=${note.user}
-								.href=${note.href}
-								.token=${note.token}
-								.showavatar=${typeof note.showAvatar === 'boolean' ? note.showAvatar : true}
-								.me=${note.me ? note.me : false}
-								.createdat=${note.createdAt}
-								.updatedat=${note.updatedAt}
-								.text=${note.text}
-								.canedit=${note.canEdit ? note.canEdit : false}
-								.candelete=${note.canDelete ? note.canDelete : false}
-								.private=${note.private ? note.private : false}
-								.dateformat=${this.dateformat}
-								.contextmenulabel=${note.contextmenulabel}
-								.editstring=${this.editstring}
-								.deletestring=${this.deletestring}
-								.privatelabel=${this.privatelabel}
-								.addnotestring=${this.addnotestring}
-								.savenotestring=${this.savenotestring}
-								.discardnotestring=${this.discardnotestring}
-								.editplaceholder=${this.editplaceholder}
-							>
-								<div slot="description">${this.description(note)}</div>
-								<div slot="settings">${this.settings(note)}</div>
-							</d2l-note>
-						</li>
-					`)}
-			</ol>` : (this.emptystring === '' ? '' : html`<div class="d2l-body-standard d2l-note-emptystring">${this.emptystring !== undefined || this.enternotestring !== undefined ? this.emptystring || this.enternotestring : this.localize('empty')}</div>`)}
+					<ol>
+						${notes.map(note => html`
+							<li>
+								<d2l-note
+									.id=${note.id ? note.id : ''}
+									.user=${note.user}
+									.href=${note.href}
+									.token=${note.token}
+									.showavatar=${typeof note.showAvatar === 'boolean' ? note.showAvatar : true}
+									.me=${note.me ? note.me : false}
+									.createdat=${note.createdAt}
+									.updatedat=${note.updatedAt}
+									.text=${note.text}
+									.canedit=${note.canEdit ? note.canEdit : false}
+									.candelete=${note.canDelete ? note.canDelete : false}
+									.private=${note.private ? note.private : false}
+									.dateformat=${this.dateFormat}
+									.contextmenulabel=${note.contextmenulabel}
+									.editstring=${this.editString}
+									.deletestring=${this.deleteString}
+									.privatelabel=${this.privateLabel}
+									.addnotestring=${this.addNoteString}
+									.savenotestring=${this.saveNoteString}
+									.discardnotestring=${this.discardNoteString}
+									.editplaceholder=${this.editPlaceholder}
+								>
+									<div slot="description">${this.description(note)}</div>
+									<div slot="settings">${this.settings(note)}</div>
+								</d2l-note>
+							</li>
+						`)}
+					</ol>
+				` : (this.emptyString === '' ? '' : html`
+					<div class="d2l-body-standard d2l-note-emptystring">
+						${this.emptyString !== undefined || this.enterNoteString !== undefined ? this.emptyString || this.enterNoteString : this.localize('empty')}
+					</div>
+				`)}
 
 				${hasmore ? html`
-				<div
-					class="d2l-notes-more-less"
-					@click=${this.handleMoreLess}
-					@tap=${this.handleMoreLess}
-				>
+					<div
+						class="d2l-notes-more-less"
+						@click=${this.handleMoreLess}
+						@tap=${this.handleMoreLess}
+					>
 					<div class="d2l-notes-more-less-separator"></div>
 					<d2l-button-subtle
 						class="d2l-notes-load-more-less"
-						text="${(this.hasmore || this.collapsed) ? this.loadmorestring ? this.loadmorestring : this.localize('more') : this.loadlessstring ? this.loadlessstring : this.localize('less')}"
+						text="${(this.hasMore || this.collapsed) ? this.loadMoreString ? this.loadMoreString : this.localize('more') : this.loadLessString ? this.loadLessString : this.localize('less')}"
 					></d2l-button-subtle>
-					<div class="d2l-notes-more-less-separator"></div>
-				</div>
+					<div class="d2l-notes-more-less-separator"></div></div>
 				` : null}
 
-				${(hasmore || this.notes.length) && this.cancreate ? html`<hr>` : null}
+				${(hasmore || this.notes.length) && this.canCreate ? html`<hr>` : null}
 
-				${this.cancreate ? html`${notes.length > 0 && this.enternotestring !== undefined ? html`<div class='d2l-notes-enter-note-string'>${this.enternotestring}</div>` : html``}
-					<d2l-note-edit new placeholder="${this.editplaceholder}">
-						<slot class="d2l-body-standard" name="description" slot="description"><div>${this.description()}</div></slot>
-						<div slot="settings">${this.settings()}</div>
-					</d2l-note-edit>` : null}
+				${this.canCreate ? html`${notes.length > 0 && this.enterNoteString !== undefined ? html`<div class='d2l-notes-enter-note-string'>${this.enterNoteString}</div>` : html``}
+				<d2l-note-edit new placeholder="${this.editPlaceholder}">
+					<slot class="d2l-body-standard" name="description" slot="description"><div>${this.description()}</div></slot>
+					<div slot="settings">${this.settings()}</div>
+				</d2l-note-edit>` : null}
 			</div>
 		`;
 	}


### PR DESCRIPTION
Bringing this repo up to date with the current Lit 2 standards. This includes:

* Updating attributes to use proper syntax and case
* switching `static get properties() {}` for `static properties ={}`
* switching `static get styles() {}` for `static styles = []`